### PR TITLE
Update propTypes to remove warnings

### DIFF
--- a/src/components/ScrollTrack/ScrollTrackPropTypes.js
+++ b/src/components/ScrollTrack/ScrollTrackPropTypes.js
@@ -7,7 +7,7 @@ const propTypes = {
     left: PropTypes.number,
     parentWidth: PropTypes.number,
     trackWidth: PropTypes.number,
-    trackBounds: PropTypes.number
+    trackBounds: PropTypes.object
   })
 }
 

--- a/src/components/ScrollTrack/equalWidthTrack.js
+++ b/src/components/ScrollTrack/equalWidthTrack.js
@@ -19,10 +19,12 @@ const equalWidthTrack = (childWidth) => {
   return (WrappedComponent) => {
     class EqualWidthTrack extends PureComponent {
       static propTypes = {
-        trackProps: ScrollTrackPropTypes.trackProps.isRequired
+        trackProps: ScrollTrackPropTypes.trackProps
       }
 
       render() {
+        if (!this.props.trackProps) { return null }
+
         const { left, parentWidth } = this.props.trackProps
 
         const startIndex = Math.floor(Math.abs(left)/childWidth)


### PR DESCRIPTION
trackProps is undefined on initial render, and is only set after the bounding box calculation is finished.

```
Warning: Failed prop type: The prop `trackProps` is marked as required in `EqualWidthTrack`, but its value is `undefined`.
```


trackBounds is an object not a number.
```
Warning: Failed prop type: Invalid prop `trackProps.trackBounds` of type `object` supplied to `EqualWidthTrack`, expected `number`.
```