### PR TITLE
[spacing] Export spacing and add docs

### DIFF
--- a/docs/spacing.md
+++ b/docs/spacing.md
@@ -34,7 +34,7 @@ const styles = {
   ...spacing.MARGIN_X_LG,              // => { marginLeft: 32, marginRight: 32 }
 
   // Positioning
-  ...spacing.LEFT_8                    // => { left: 8 }
-  ...spacing.RIGHT_16,                 // => { right: 16 }
+  ...spacing.LEFT_XS                   // => { left: 8 }
+  ...spacing.RIGHT_SM,                 // => { right: 16 }
 }
 ```

--- a/docs/spacing.md
+++ b/docs/spacing.md
@@ -1,0 +1,35 @@
+The spacing module is based on the design system's base 8 spacing.
+Using predefined values for padding and margin help us keep things visually consistent.
+
+### Sizes
+| Property   | Px value  |
+|------------|-----------|
+| XS         | 8px       |
+| SM         | 16px      |
+| MD         | 24px      |
+| LG         | 32px      |
+| XL         | 48px      |
+| HUGE       | 64px      |
+
+### Example usage:
+
+```markdown
+import { spacing } from 'ic-snacks'
+
+// If you need to reference the pixel values directly
+spacing.SM //=> 16
+
+const styles = {
+  // Padding/margin for all sides
+  ...spacing.PADDING_SM,               // => { padding: 16 }
+  ...spacing.MARGIN_SM,                // => { margin: 16 }
+
+  // Padding/margin in one direction
+  ...spacing.PADDING_LEFT_MD,          // => { paddingLeft: 24 }
+  ...spacing.MARGIN_TOP_MD,            // => { marginLeft: 24 }
+
+  // Padding/margin along one dimension
+  ...spacing.PADDING_Y_XL              // => { paddingTop: 64, paddingBottom: 64 }
+  ...spacing.MARGIN_X_LG,              // => { marginLeft: 32, marginRight: 32 }
+}
+```

--- a/docs/spacing.md
+++ b/docs/spacing.md
@@ -1,6 +1,7 @@
-The spacing module is based on the design system's base 8 spacing.
-Using predefined values for padding and margin help us keep things visually consistent.
+The spacing module exports values which can be used for padding, margin, and positioning (top, left, bottom, right).
+Using predefined values for spacing help us keep things visually consistent.
 
+The pixel values are a base-8 strategy as defined by the design system.
 ### Sizes
 | Property   | Px value  |
 |------------|-----------|
@@ -31,5 +32,9 @@ const styles = {
   // Padding/margin along one dimension
   ...spacing.PADDING_Y_XL              // => { paddingTop: 64, paddingBottom: 64 }
   ...spacing.MARGIN_X_LG,              // => { marginLeft: 32, marginRight: 32 }
+
+  // Positioning
+  ...spacing.LEFT_8                    // => { left: 8 }
+  ...spacing.RIGHT_16,                 // => { right: 16 }
 }
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import responsive from './styles/responsive'
 import Row from './components/Grid/Row'
 import ScrollTrack from './components/ScrollTrack/ScrollTrack'
 import SetStyles from './styles/SetStyles'
+import spacing from './styles/spacing'
 import zIndex from './styles/zIndex'
 import themer from './styles/themer/index'
 
@@ -26,6 +27,7 @@ export {
   Row,
   ScrollTrack,
   SetStyles,
+  spacing,
   themer,
   zIndex
 }

--- a/src/styles/spacing/__tests__/spacing.spec.js
+++ b/src/styles/spacing/__tests__/spacing.spec.js
@@ -1,0 +1,31 @@
+import spacing from '../'
+import { spacings } from '../'
+
+const {
+  SM,
+  MD,
+  LG,
+  XL
+} = spacings
+
+describe('spacing', () => {
+  it('exports margin and padding for all directions', () => {
+    expect(spacing.MARGIN_SM).toEqual({margin: SM})
+    expect(spacing.PADDING_SM).toEqual({padding: SM})
+  })
+
+  it('exports margin and padding for X and Y axes', () => {
+    expect(spacing.MARGIN_X_MD).toEqual({marginLeft: MD, marginRight: MD})
+    expect(spacing.PADDING_Y_MD).toEqual({paddingTop: MD, paddingBottom: MD})
+  })
+
+  it('exports margin and padding for each individual direction', () => {
+    expect(spacing.MARGIN_LEFT_LG).toEqual({marginLeft: LG})
+    expect(spacing.PADDING_TOP_LG).toEqual({paddingTop: LG})
+  })
+
+  it('exports positioning (top, left, right, bottom)', () => {
+    expect(spacing.LEFT_XL).toEqual({left: XL})
+    expect(spacing.BOTTOM_XL).toEqual({bottom: XL})
+  })
+})

--- a/src/styles/spacing/index.js
+++ b/src/styles/spacing/index.js
@@ -22,8 +22,15 @@ export const spacings = {
 const finalSpacings = {}
 Object.keys(spacings).forEach(spacing => {
   const pxValue = spacings[spacing]
+
   finalSpacings[`MARGIN_${spacing}`] = { margin: pxValue }
   finalSpacings[`PADDING_${spacing}`] = { padding: pxValue }
+
+  finalSpacings[`PADDING_X_${spacing}`] = { paddingLeft: pxValue, paddingRight: pxValue }
+  finalSpacings[`PADDING_Y_${spacing}`] = { paddingTop: pxValue, paddingBottom: pxValue }
+  finalSpacings[`MARGIN_X_${spacing}`] = { marginLeft: pxValue, marginRight: pxValue }
+  finalSpacings[`MARGIN_Y_${spacing}`] = { marginTop: pxValue, marginBottom: pxValue }
+
   DIRECTIONS.forEach(direction => {
     finalSpacings[`MARGIN_${direction}_${spacing}`] = {
       [`margin${capitalize(direction)}`]: pxValue

--- a/src/styles/spacing/index.js
+++ b/src/styles/spacing/index.js
@@ -7,7 +7,7 @@
 //     // Or,
 //     // ...spacing.PADDING_X_MD // => { paddingLeft: 24, paddingRight: 24 }
 //     // Or
-//     // ...spacing.LEFT_8 // => { left: 8 }
+//     // ...spacing.LEFT_XS // => { left: 8 }
 //   }
 const DIRECTIONS = ['TOP', 'LEFT', 'BOTTOM', 'RIGHT']
 export const spacings = {

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -25,6 +25,10 @@ module.exports = {
       content: 'docs/colors.md'
     },
     {
+      name: 'Spacing',
+      content: 'docs/spacing.md'
+    },
+    {
       name: 'Icons',
       content: 'docs/icons.md'
     },


### PR DESCRIPTION
### What

Exports the spacing module from snacks, and adds a section to the style guide with a few examples.
![screen shot 2017-09-19 at 3 15 34 pm](https://user-images.githubusercontent.com/6454987/30617989-6af8e4e8-9d4d-11e7-8f0a-9e5964a9dcc3.png)

I didn't include any runnable examples, but certainly open to doing so.
