### PR TITLE
Add event hooks into ScrollTrack

### DIFF
--- a/src/components/ScrollTrack/ScrollTrack.js
+++ b/src/components/ScrollTrack/ScrollTrack.js
@@ -18,6 +18,23 @@ class ScrollTrack extends Component {
     /** Manually control left positioning of ScrollTrack */
     leftOverride: PropTypes.number,
 
+    /**
+    * A callback called before sliding to next set.
+    * ** Passed function must return a promsie **
+    * -- will wait for promise resolution before continuing slide.
+    * Use for high levels of control
+    */
+    onBeforeNext: PropTypes.func,
+
+    /**  function to be called before sliding to previous set. */
+    onBeforeBack: PropTypes.func,
+
+    /**  function to be called after sliding to next set. */
+    onAfterNext: PropTypes.func,
+
+    /**  function to be called after sliding to previous set. */
+    onAfterBack: PropTypes.func,
+
     /** Style top level element */
     style: PropTypes.object,
 
@@ -142,21 +159,62 @@ class ScrollTrack extends Component {
     const { parentWidth, trackWidth } = this.getNodeWidths()
     let nextForward = this.state.left - parentWidth
     const fullForward = parentWidth - trackWidth
+    const { onBeforeNext, onAfterNext } = this.props
 
     // already is, or is going to be, full forward
     if (nextForward <= fullForward) { nextForward = fullForward }
 
-    this.setState({ left: nextForward }, this.computeSlideAttributes)
+    const callbackProps = {
+      atStart: trackWidth <= parentWidth,
+      atEnd: fullForward === nextForward,
+      slideTo: nextForward,
+      parentWidth,
+      trackWidth
+    }
+
+    if (!onBeforeNext) {
+      this.setState({ left: nextForward }, () => {
+        this.computeSlideAttributes()
+        onAfterNext && onAfterNext(callbackProps)
+      })
+    } else {
+      onBeforeNext(callbackProps).then(() => {
+        this.setState({ left: nextForward }, () => {
+          this.computeSlideAttributes()
+          onAfterNext && onAfterNext(callbackProps)
+        })
+      })
+    }
   }
 
   slideBack = () => {
-    const { parentWidth } = this.getNodeWidths()
+    const { parentWidth, trackWidth } = this.getNodeWidths()
     let nextBack = this.state.left + parentWidth
+    const { onBeforeBack, onAfterBack } = this.props
 
     // already is, or is going to be, full back
     if (this.state.left >= 0 || nextBack >= 0) { nextBack = 0 }
 
-    this.setState({ left: nextBack }, this.computeSlideAttributes)
+    const callbackProps = {
+      atStart: nextBack === 0,
+      atEnd: false,
+      slideTo: nextBack,
+      parentWidth,
+      trackWidth
+    }
+
+    if (!onBeforeBack) {
+      this.setState({ left: nextBack }, () => {
+        this.computeSlideAttributes()
+        onAfterBack && onAfterBack(callbackProps)
+      })
+    } else {
+      onBeforeBack(callbackProps)
+      this.setState({ left: nextBack }, () => {
+        this.computeSlideAttributes()
+        onAfterBack && onAfterBack(callbackProps)
+      })
+    }
   }
 
   renderRightArrow = () => {

--- a/src/components/ScrollTrack/ScrollTrack.js
+++ b/src/components/ScrollTrack/ScrollTrack.js
@@ -173,15 +173,17 @@ class ScrollTrack extends Component {
     }
 
     if (!onBeforeNext) {
-      this.setState({ left: nextForward }, () => {
-        this.computeSlideAttributes()
-        onAfterNext && onAfterNext(callbackProps)
+      this.updateLeftValue({
+        left: nextForward,
+        callback: onAfterNext,
+        callbackProps
       })
     } else {
       onBeforeNext(callbackProps).then(() => {
-        this.setState({ left: nextForward }, () => {
-          this.computeSlideAttributes()
-          onAfterNext && onAfterNext(callbackProps)
+        this.updateLeftValue({
+          left: nextForward,
+          callback: onAfterNext,
+          callbackProps
         })
       })
     }
@@ -203,18 +205,20 @@ class ScrollTrack extends Component {
       trackWidth
     }
 
-    if (!onBeforeBack) {
-      this.setState({ left: nextBack }, () => {
-        this.computeSlideAttributes()
-        onAfterBack && onAfterBack(callbackProps)
-      })
-    } else {
-      onBeforeBack(callbackProps)
-      this.setState({ left: nextBack }, () => {
-        this.computeSlideAttributes()
-        onAfterBack && onAfterBack(callbackProps)
-      })
-    }
+    onBeforeBack && onBeforeBack(callbackProps)
+
+    this.updateLeftValue({
+      left: nextBack,
+      callback: onAfterBack,
+      callbackProps
+    })
+  }
+
+  updateLeftValue({left, callback, callbackProps}) {
+    this.setState({ left }, () => {
+      this.computeSlideAttributes()
+      callback && callback(callbackProps)
+    })
   }
 
   renderRightArrow = () => {

--- a/src/components/ScrollTrack/ScrollTrack.js
+++ b/src/components/ScrollTrack/ScrollTrack.js
@@ -9,6 +9,8 @@ import Radium        from 'radium'
 import PropTypes     from 'prop-types'
 import _             from 'underscore'
 
+const noOp = () => {} // eslint-disable-line no-empty-function
+
 @Radium
 class ScrollTrack extends Component {
   static equalWidthTrack = equalWidthTrack
@@ -53,7 +55,11 @@ class ScrollTrack extends Component {
       RightArrow: {},
       Track: {}
     },
-    style: {}
+    style: {},
+    onBeforeBack: noOp,
+    onAfterNext: noOp,
+    onAfterBack: noOp,
+    onBeforeNext: () => new Promise(resolve => resolve())
   }
 
   constructor(props) {
@@ -172,21 +178,13 @@ class ScrollTrack extends Component {
       trackWidth
     }
 
-    if (!onBeforeNext) {
+    onBeforeNext(callbackProps).then(() => {
       this.updateLeftValue({
         left: nextForward,
         callback: onAfterNext,
         callbackProps
       })
-    } else {
-      onBeforeNext(callbackProps).then(() => {
-        this.updateLeftValue({
-          left: nextForward,
-          callback: onAfterNext,
-          callbackProps
-        })
-      })
-    }
+    })
   }
 
   slideBack = () => {
@@ -205,7 +203,7 @@ class ScrollTrack extends Component {
       trackWidth
     }
 
-    onBeforeBack && onBeforeBack(callbackProps)
+    onBeforeBack(callbackProps)
 
     this.updateLeftValue({
       left: nextBack,
@@ -217,7 +215,7 @@ class ScrollTrack extends Component {
   updateLeftValue({left, callback, callbackProps}) {
     this.setState({ left }, () => {
       this.computeSlideAttributes()
-      callback && callback(callbackProps)
+      callback(callbackProps)
     })
   }
 

--- a/src/components/ScrollTrack/__tests__/ScrollTrack.spec.js
+++ b/src/components/ScrollTrack/__tests__/ScrollTrack.spec.js
@@ -178,3 +178,30 @@ it('onAfter promises & callbacks called correctly', async () => {
   expect(onAfterBack.calledWith({})).toBeTruthy
   expect(onAfterBack.calledAfter(onBeforeBack)).toBeTruthy
 })
+
+it('works without any callbacks passed in', async () => {
+  const track = mount(
+    <StyleRoot>
+      <div>
+        <ScrollTrack>
+          <p>one</p>
+          <p>two</p>
+          <p>three</p>
+          <p>four</p>
+          <p>five</p>
+          <p>six</p>
+          <p>seven</p>
+        </ScrollTrack>
+      </div>
+    </StyleRoot>
+  )
+
+  // show and click next
+  track.find(ScrollTrack).node.showRightArrow()
+  track.find('button').simulate('click')
+
+  // show and click back
+  track.find(ScrollTrack).node.hideRightArrow()
+  track.find(ScrollTrack).node.showLeftArrow()
+  track.find('button').simulate('click')
+})

--- a/src/components/ScrollTrack/__tests__/ScrollTrack.spec.js
+++ b/src/components/ScrollTrack/__tests__/ScrollTrack.spec.js
@@ -3,6 +3,7 @@ import renderer from 'react-test-renderer'
 import ScrollTrack from '../ScrollTrack'
 import { StyleRoot } from 'radium'
 import { mount } from 'enzyme'
+import { spy } from 'sinon'
 
 it('renders ScrollTrack correctly', () => {
   const tree = renderer.create(
@@ -84,4 +85,96 @@ it('renders ScrollTrack buttons correctly', () => {
   expect(track.find('button')).toHaveLength(2)
   track.find(ScrollTrack).node.hideArrows()
   expect(track.find('button')).toHaveLength(0)
+})
+
+it('onBefore promises & callbacks called correctly', async () => {
+  const onBeforeNext = spy()
+  const onBeforeBack = spy()
+  const track = mount(
+    <StyleRoot>
+      <div>
+        <ScrollTrack
+          onBeforeNext={() => {
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                  onBeforeNext()
+                  resolve()
+                }, 1)
+            })
+          }}
+          onBeforeBack={() => { onBeforeBack() }}
+        >
+          <p>one</p>
+          <p>two</p>
+          <p>three</p>
+          <p>four</p>
+          <p>five</p>
+          <p>six</p>
+          <p>seven</p>
+        </ScrollTrack>
+      </div>
+    </StyleRoot>
+  )
+
+  // show and click next
+  track.find(ScrollTrack).node.showRightArrow()
+  track.find('button').simulate('click')
+  await expect(onBeforeNext.calledOnce).resolves.toBeTruthy
+  await expect(onBeforeNext.calledWith({})).resolves.toBeTruthy
+
+  // show and click back
+  track.find(ScrollTrack).node.hideRightArrow()
+  track.find(ScrollTrack).node.showLeftArrow()
+  track.find('button').simulate('click')
+  await expect(onBeforeBack.calledOnce).resolves.toBeTruthy
+  await expect(onBeforeBack.calledWith({})).resolves.toBeTruthy
+})
+
+it('onAfter promises & callbacks called correctly', async () => {
+  const onBeforeNext = spy()
+  const onBeforeBack = spy()
+  const onAfterNext = spy()
+  const onAfterBack = spy()
+  const track = mount(
+    <StyleRoot>
+      <div>
+        <ScrollTrack
+          onBeforeBack={onBeforeBack}
+          onAfterBack={onAfterBack}
+          onAfterNext={onAfterNext}
+          onBeforeNext={() => {
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                  onBeforeNext()
+                  resolve()
+                }, 1)
+            })
+          }}
+        >
+          <p>one</p>
+          <p>two</p>
+          <p>three</p>
+          <p>four</p>
+          <p>five</p>
+          <p>six</p>
+          <p>seven</p>
+        </ScrollTrack>
+      </div>
+    </StyleRoot>
+  )
+
+  // show and click next
+  track.find(ScrollTrack).node.showRightArrow()
+  track.find('button').simulate('click')
+  expect(onAfterNext.calledOnce).toBeTruthy
+  expect(onAfterNext.calledWith({})).toBeTruthy
+  await expect(onAfterBack.calledAfter(onBeforeNext)).resolves.toBeTruthy
+
+  // show and click back
+  track.find(ScrollTrack).node.hideRightArrow()
+  track.find(ScrollTrack).node.showLeftArrow()
+  track.find('button').simulate('click')
+  expect(onAfterBack.calledOnce).toBeTruthy
+  expect(onAfterBack.calledWith({})).toBeTruthy
+  expect(onAfterBack.calledAfter(onBeforeBack)).toBeTruthy
 })

--- a/src/components/ScrollTrack/docs/ScrollTrack.md
+++ b/src/components/ScrollTrack/docs/ScrollTrack.md
@@ -129,3 +129,30 @@ Example use case: *A container of item cards that all have a width of 90px and m
     <ScrollTrack>
       <CustomComponent />
     </ScrollTrack>
+
+
+Using callbacks
+```js static
+  <ScrollTrack
+    onBeforeNext={(props) => {
+      return new Promise((resolve, reject) => {
+          setTimeout(() => {
+            console.log('before next!', props)
+            resolve()
+          }, 1000)
+      })
+    }}
+    onAfterNext={(props) => { console.log('after next!', props) }}
+    onBeforeBack={(props) => { console.log('before back!', props) }}
+    onAfterBack={(props) => { console.log('after back!', props) }}
+  >
+    <div>
+      <Icon name="cart" style={styles} />
+      <Icon name="cart" style={styles} />
+      <Icon name="cart" style={styles} />
+      <Icon name="cart" style={styles} />
+      <Icon name="cart" style={styles} />
+      <Icon name="cart" style={styles} />
+    </div>
+  </ScrollTrack>
+```


### PR DESCRIPTION
This adds `onBeforeNext`, `onBeforeBack`, `onAfterNext`, `onAfterBack` callbacks to the `ScrollTrack` component. These are useful for things like adding async pagination to a carousel.