### PR TITLE
Use translate3d for ScrollTrack

### DIFF
--- a/src/components/NavigationPills/__tests__/__snapshots__/NavigationPills.spec.js.snap
+++ b/src/components/NavigationPills/__tests__/__snapshots__/NavigationPills.spec.js.snap
@@ -19,9 +19,9 @@ exports[`renders NavigationPills correctly 1`] = `
         data-radium={true}
         style={
           Object {
-            "left": 0,
             "position": "relative",
-            "transition": "left 150ms ease-in-out",
+            "transform": "translate3d(0px, 0, 0)",
+            "transition": "transform 150ms ease-in-out",
             "whiteSpace": "nowrap",
           }
         }
@@ -270,9 +270,9 @@ exports[`renders NavigationPills wihtout label correctly 1`] = `
         data-radium={true}
         style={
           Object {
-            "left": 0,
             "position": "relative",
-            "transition": "left 150ms ease-in-out",
+            "transform": "translate3d(0px, 0, 0)",
+            "transition": "transform 150ms ease-in-out",
             "whiteSpace": "nowrap",
           }
         }

--- a/src/components/ScrollTrack/ScrollTrack.js
+++ b/src/components/ScrollTrack/ScrollTrack.js
@@ -291,8 +291,8 @@ class ScrollTrack extends Component {
         <div
           style={[
             {
-              left: this.state.left,
-              transition: `left ${scrollSpeed}ms ${scrollTimingFunction}`,
+              transition: `transform ${scrollSpeed}ms ${scrollTimingFunction}`,
+              transform: `translate3d(${this.state.left}px, 0, 0)`
             },
             innerContainerStyles
           ]}

--- a/src/components/ScrollTrack/__tests__/__snapshots__/ScrollTrack.spec.js.snap
+++ b/src/components/ScrollTrack/__tests__/__snapshots__/ScrollTrack.spec.js.snap
@@ -19,9 +19,9 @@ exports[`renders ScrollTrack correctly 1`] = `
         data-radium={true}
         style={
           Object {
-            "left": 0,
             "position": "relative",
-            "transition": "left 150ms ease-in-out",
+            "transform": "translate3d(0px, 0, 0)",
+            "transition": "transform 150ms ease-in-out",
             "whiteSpace": "nowrap",
           }
         }
@@ -89,9 +89,9 @@ exports[`renders ScrollTrack with animation props correctly 1`] = `
         data-radium={true}
         style={
           Object {
-            "left": 0,
             "position": "relative",
-            "transition": "left 1000ms ease-in",
+            "transform": "translate3d(0px, 0, 0)",
+            "transition": "transform 1000ms ease-in",
             "whiteSpace": "nowrap",
           }
         }


### PR DESCRIPTION
This converts the use of `left` for scroll track animation to `translate3d`. The  change should be negligible, but the performance win is fairly large for more complex DOM arrangements.