### PR TITLE
Hide ScrollTrack buttons via styles rather than not rendering

### DIFF
--- a/src/components/NavigationPills/__tests__/__snapshots__/NavigationPills.spec.js.snap
+++ b/src/components/NavigationPills/__tests__/__snapshots__/NavigationPills.spec.js.snap
@@ -14,6 +14,62 @@ exports[`renders NavigationPills correctly 1`] = `
         }
       }
     >
+      <button
+        aria-label="back"
+        className="rmq-4534e6b"
+        data-radium={true}
+        disabled={undefined}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#43B02A",
+            "border": "0",
+            "borderRadius": "50%",
+            "boxShadow": "0 1px 2px 0 rgba(0, 0, 0, 0.26), 0 1px 4px 0 rgba(0, 0, 0, 0.16)",
+            "color": "#FFFFFF",
+            "display": "none",
+            "height": "48px",
+            "left": 8,
+            "lineHeight": "1",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": "5px",
+            "transition": "background-color 150ms ease-in-out",
+            "width": "48px",
+            "zIndex": 100,
+          }
+        }
+      >
+        <i
+          aria-hidden={true}
+          data-radium={true}
+          onClick={undefined}
+          style={
+            Object {
+              "fontFamily": "ic-icons",
+              "fontSize": "20px",
+              "fontSmoothing": "antialiased",
+              "fontStyle": "normal",
+              "fontVariant": "normal",
+              "fontWeight": "normal",
+              "lineHeight": "1",
+              "osxFontSmoothing": "grayscale",
+              "position": "relative",
+              "speak": "none",
+              "textTransform": "none",
+            }
+          }
+        >
+          
+        </i>
+      </button>
       <div
         className="rmq-16b35912"
         data-radium={true}
@@ -234,6 +290,62 @@ exports[`renders NavigationPills correctly 1`] = `
           </div>
         </div>
       </div>
+      <button
+        aria-label="next"
+        className="rmq-4534e6b"
+        data-radium={true}
+        disabled={undefined}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#43B02A",
+            "border": "0",
+            "borderRadius": "50%",
+            "boxShadow": "0 1px 2px 0 rgba(0, 0, 0, 0.26), 0 1px 4px 0 rgba(0, 0, 0, 0.16)",
+            "color": "#FFFFFF",
+            "display": "none",
+            "height": "48px",
+            "lineHeight": "1",
+            "position": "absolute",
+            "right": 8,
+            "textAlign": "center",
+            "top": "5px",
+            "transition": "background-color 150ms ease-in-out",
+            "width": "48px",
+            "zIndex": 100,
+          }
+        }
+      >
+        <i
+          aria-hidden={true}
+          data-radium={true}
+          onClick={undefined}
+          style={
+            Object {
+              "fontFamily": "ic-icons",
+              "fontSize": "20px",
+              "fontSmoothing": "antialiased",
+              "fontStyle": "normal",
+              "fontVariant": "normal",
+              "fontWeight": "normal",
+              "lineHeight": "1",
+              "osxFontSmoothing": "grayscale",
+              "position": "relative",
+              "speak": "none",
+              "textTransform": "none",
+            }
+          }
+        >
+          
+        </i>
+      </button>
     </div>
   </div>
   <style
@@ -244,7 +356,8 @@ exports[`renders NavigationPills correctly 1`] = `
       display: block !important;
       -ms-overflow-style: none !important;
       overflow: -moz-scrollbars-none !important;
-      webkit-overflow-scrolling: touch !important;}}",
+      webkit-overflow-scrolling: touch !important;}}
+      @media (max-width: 767px){ .rmq-4534e6b{display: none !important;}}",
       }
     }
   />
@@ -265,6 +378,62 @@ exports[`renders NavigationPills wihtout label correctly 1`] = `
         }
       }
     >
+      <button
+        aria-label="back"
+        className="rmq-4534e6b"
+        data-radium={true}
+        disabled={undefined}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#43B02A",
+            "border": "0",
+            "borderRadius": "50%",
+            "boxShadow": "0 1px 2px 0 rgba(0, 0, 0, 0.26), 0 1px 4px 0 rgba(0, 0, 0, 0.16)",
+            "color": "#FFFFFF",
+            "display": "none",
+            "height": "48px",
+            "left": 8,
+            "lineHeight": "1",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": "5px",
+            "transition": "background-color 150ms ease-in-out",
+            "width": "48px",
+            "zIndex": 100,
+          }
+        }
+      >
+        <i
+          aria-hidden={true}
+          data-radium={true}
+          onClick={undefined}
+          style={
+            Object {
+              "fontFamily": "ic-icons",
+              "fontSize": "20px",
+              "fontSmoothing": "antialiased",
+              "fontStyle": "normal",
+              "fontVariant": "normal",
+              "fontWeight": "normal",
+              "lineHeight": "1",
+              "osxFontSmoothing": "grayscale",
+              "position": "relative",
+              "speak": "none",
+              "textTransform": "none",
+            }
+          }
+        >
+          
+        </i>
+      </button>
       <div
         className="rmq-16b35912"
         data-radium={true}
@@ -475,6 +644,62 @@ exports[`renders NavigationPills wihtout label correctly 1`] = `
           </div>
         </div>
       </div>
+      <button
+        aria-label="next"
+        className="rmq-4534e6b"
+        data-radium={true}
+        disabled={undefined}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#43B02A",
+            "border": "0",
+            "borderRadius": "50%",
+            "boxShadow": "0 1px 2px 0 rgba(0, 0, 0, 0.26), 0 1px 4px 0 rgba(0, 0, 0, 0.16)",
+            "color": "#FFFFFF",
+            "display": "none",
+            "height": "48px",
+            "lineHeight": "1",
+            "position": "absolute",
+            "right": 8,
+            "textAlign": "center",
+            "top": "5px",
+            "transition": "background-color 150ms ease-in-out",
+            "width": "48px",
+            "zIndex": 100,
+          }
+        }
+      >
+        <i
+          aria-hidden={true}
+          data-radium={true}
+          onClick={undefined}
+          style={
+            Object {
+              "fontFamily": "ic-icons",
+              "fontSize": "20px",
+              "fontSmoothing": "antialiased",
+              "fontStyle": "normal",
+              "fontVariant": "normal",
+              "fontWeight": "normal",
+              "lineHeight": "1",
+              "osxFontSmoothing": "grayscale",
+              "position": "relative",
+              "speak": "none",
+              "textTransform": "none",
+            }
+          }
+        >
+          
+        </i>
+      </button>
     </div>
   </div>
   <style
@@ -485,7 +710,8 @@ exports[`renders NavigationPills wihtout label correctly 1`] = `
       display: block !important;
       -ms-overflow-style: none !important;
       overflow: -moz-scrollbars-none !important;
-      webkit-overflow-scrolling: touch !important;}}",
+      webkit-overflow-scrolling: touch !important;}}
+      @media (max-width: 767px){ .rmq-4534e6b{display: none !important;}}",
       }
     }
   />
@@ -506,6 +732,62 @@ exports[`renders NavigationPills with elementAttributes correctly 1`] = `
         }
       }
     >
+      <button
+        aria-label="back"
+        className="rmq-4534e6b"
+        data-radium={true}
+        disabled={undefined}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#43B02A",
+            "border": "0",
+            "borderRadius": "50%",
+            "boxShadow": "0 1px 2px 0 rgba(0, 0, 0, 0.26), 0 1px 4px 0 rgba(0, 0, 0, 0.16)",
+            "color": "#FFFFFF",
+            "display": "none",
+            "height": "48px",
+            "left": 8,
+            "lineHeight": "1",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": "5px",
+            "transition": "background-color 150ms ease-in-out",
+            "width": "48px",
+            "zIndex": 100,
+          }
+        }
+      >
+        <i
+          aria-hidden={true}
+          data-radium={true}
+          onClick={undefined}
+          style={
+            Object {
+              "fontFamily": "ic-icons",
+              "fontSize": "20px",
+              "fontSmoothing": "antialiased",
+              "fontStyle": "normal",
+              "fontVariant": "normal",
+              "fontWeight": "normal",
+              "lineHeight": "1",
+              "osxFontSmoothing": "grayscale",
+              "position": "relative",
+              "speak": "none",
+              "textTransform": "none",
+            }
+          }
+        >
+          
+        </i>
+      </button>
       <div
         className="rmq-16b35912"
         data-radium={true}
@@ -728,6 +1010,62 @@ exports[`renders NavigationPills with elementAttributes correctly 1`] = `
           </div>
         </div>
       </div>
+      <button
+        aria-label="next"
+        className="rmq-4534e6b"
+        data-radium={true}
+        disabled={undefined}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#43B02A",
+            "border": "0",
+            "borderRadius": "50%",
+            "boxShadow": "0 1px 2px 0 rgba(0, 0, 0, 0.26), 0 1px 4px 0 rgba(0, 0, 0, 0.16)",
+            "color": "#FFFFFF",
+            "display": "none",
+            "height": "48px",
+            "lineHeight": "1",
+            "position": "absolute",
+            "right": 8,
+            "textAlign": "center",
+            "top": "5px",
+            "transition": "background-color 150ms ease-in-out",
+            "width": "48px",
+            "zIndex": 100,
+          }
+        }
+      >
+        <i
+          aria-hidden={true}
+          data-radium={true}
+          onClick={undefined}
+          style={
+            Object {
+              "fontFamily": "ic-icons",
+              "fontSize": "20px",
+              "fontSmoothing": "antialiased",
+              "fontStyle": "normal",
+              "fontVariant": "normal",
+              "fontWeight": "normal",
+              "lineHeight": "1",
+              "osxFontSmoothing": "grayscale",
+              "position": "relative",
+              "speak": "none",
+              "textTransform": "none",
+            }
+          }
+        >
+          
+        </i>
+      </button>
     </div>
   </div>
   <style
@@ -738,7 +1076,8 @@ exports[`renders NavigationPills with elementAttributes correctly 1`] = `
       display: block !important;
       -ms-overflow-style: none !important;
       overflow: -moz-scrollbars-none !important;
-      webkit-overflow-scrolling: touch !important;}}",
+      webkit-overflow-scrolling: touch !important;}}
+      @media (max-width: 767px){ .rmq-4534e6b{display: none !important;}}",
       }
     }
   />

--- a/src/components/ScrollTrack/ScrollTrack.js
+++ b/src/components/ScrollTrack/ScrollTrack.js
@@ -229,19 +229,19 @@ class ScrollTrack extends Component {
 
   renderRightArrow = () => {
     const { slideButtonStyles } = componentStyles
-
-    if (!this.state.showRightArrow) { return }
+    const { showRightArrow } = this.state
 
     const { styles: { RightArrow = {} } } = this.props
     return (
       <CircleButton
         onClick={this.slideForward}
         ariaLabel='next'
-        styles={{
-          ...slideButtonStyles.default,
-          ...slideButtonStyles.right,
-          ...RightArrow
-        }}
+        styles={[
+          slideButtonStyles.default,
+          slideButtonStyles.right,
+          showRightArrow && { display: 'block' },
+          RightArrow
+        ]}
       >
         <Icon
           name='arrowRightSmallBold'
@@ -253,8 +253,7 @@ class ScrollTrack extends Component {
 
   renderLeftArrow = () => {
     const { slideButtonStyles } = componentStyles
-
-    if (!this.state.showLeftArrow) { return }
+    const { showLeftArrow } = this.state
 
     const { styles: { LeftArrow = {} } } = this.props
 
@@ -262,11 +261,12 @@ class ScrollTrack extends Component {
       <CircleButton
         onClick={this.slideBack}
         ariaLabel='back'
-        styles={{
-          ...slideButtonStyles.default,
-          ...slideButtonStyles.left,
-          ...LeftArrow
-        }}
+        styles={[
+          slideButtonStyles.default,
+          slideButtonStyles.left,
+          showLeftArrow && { display: 'block' },
+          LeftArrow
+        ]}
       >
         <Icon
           name='arrowLeftSmallBold'

--- a/src/components/ScrollTrack/ScrollTrackStyles.js
+++ b/src/components/ScrollTrack/ScrollTrackStyles.js
@@ -23,6 +23,7 @@ export default {
     default: {
       position: 'absolute',
       top: '5px',
+      display: 'none'
     },
     left: spacing.LEFT_XS,
     right: spacing.RIGHT_XS

--- a/src/components/ScrollTrack/__tests__/ScrollTrack.spec.js
+++ b/src/components/ScrollTrack/__tests__/ScrollTrack.spec.js
@@ -2,7 +2,7 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import ScrollTrack from '../ScrollTrack'
 import { StyleRoot } from 'radium'
-import { mount } from 'enzyme'
+import { ReactWrapper, mount } from 'enzyme'
 import { spy } from 'sinon'
 
 it('renders ScrollTrack correctly', () => {
@@ -62,29 +62,58 @@ it('renders ScrollTrack buttons correctly', () => {
     </StyleRoot>
   )
 
+  // should have 2 buttons
+  let buttons = track.find('button')
+  let leftButton = buttons.first()
+  let rightButton = buttons.last()
+  expect(buttons).toHaveLength(2)
+
+  // check that neither are showing
+  let leftButtonStyle = leftButton.props().style
+  let rightButtonStyle = rightButton.props().style
+  expect(leftButtonStyle.display).toEqual('none')
+  expect(rightButtonStyle.display).toEqual('none')
+
+  // show right arrow
   track.find(ScrollTrack).node.showRightArrow()
-  expect(track.find('button')).toHaveLength(1)
 
-  const rightButtonStyle = track.find('button').props().style.backgroundColor
-  expect(rightButtonStyle).toEqual(styles.RightArrow.backgroundColor)
+  // check arrow is showing and has correct styles
+  buttons = track.find('button')
+  leftButton = buttons.first()
+  rightButton = buttons.last()
+  leftButtonStyle = leftButton.props().style
+  rightButtonStyle = rightButton.props().style
 
+  // make sure styles are correct
+  expect(buttons).toHaveLength(2)
+  expect(rightButtonStyle.backgroundColor).toEqual(styles.RightArrow.backgroundColor)
+  expect(rightButtonStyle.display).toEqual('block')
+  expect(leftButtonStyle.display).toEqual('none')
+
+  // show left arrow
   track.find(ScrollTrack).node.showLeftArrow()
-  expect(track.find('button')).toHaveLength(2)
+  buttons = track.find('button')
+  leftButton = buttons.first()
+  rightButton = buttons.last()
+  leftButtonStyle = leftButton.props().style
+  rightButtonStyle = rightButton.props().style
 
-  const leftButtonStyle = track.find('button').at(0).props().style.backgroundColor
-  expect(leftButtonStyle).toEqual(styles.LeftArrow.backgroundColor)
+  // make sure styles are correct
+  expect(rightButtonStyle.display).toEqual('block')
+  expect(leftButtonStyle.display).toEqual('block')
+  expect(leftButtonStyle.backgroundColor).toEqual(styles.LeftArrow.backgroundColor)
 
-  track.find(ScrollTrack).node.hideRightArrow()
-  expect(track.find('button')).toHaveLength(1)
-
-  track.find(ScrollTrack).node.hideLeftArrow()
-  expect(track.find('button')).toHaveLength(0)
-
-  track.find(ScrollTrack).node.showRightArrow()
-  track.find(ScrollTrack).node.showLeftArrow()
-  expect(track.find('button')).toHaveLength(2)
+  // hide both arrows
   track.find(ScrollTrack).node.hideArrows()
-  expect(track.find('button')).toHaveLength(0)
+  buttons = track.find('button')
+  leftButton = buttons.first()
+  rightButton = buttons.last()
+  leftButtonStyle = leftButton.props().style
+  rightButtonStyle = rightButton.props().style
+
+  // ensure both are hidden
+  expect(leftButtonStyle.display).toEqual('none')
+  expect(rightButtonStyle.display).toEqual('none')
 })
 
 it('renders ScrollTrack with animation props correctly', () => {
@@ -140,14 +169,14 @@ it('onBefore promises & callbacks called correctly', async () => {
 
   // show and click next
   track.find(ScrollTrack).node.showRightArrow()
-  track.find('button').simulate('click')
+  track.find('button').last().simulate('click')
   await expect(onBeforeNext.calledOnce).resolves.toBeTruthy
   await expect(onBeforeNext.calledWith({})).resolves.toBeTruthy
 
   // show and click back
   track.find(ScrollTrack).node.hideRightArrow()
   track.find(ScrollTrack).node.showLeftArrow()
-  track.find('button').simulate('click')
+  track.find('button').first().simulate('click')
   await expect(onBeforeBack.calledOnce).resolves.toBeTruthy
   await expect(onBeforeBack.calledWith({})).resolves.toBeTruthy
 })
@@ -187,7 +216,7 @@ it('onAfter promises & callbacks called correctly', async () => {
 
   // show and click next
   track.find(ScrollTrack).node.showRightArrow()
-  track.find('button').simulate('click')
+  track.find('button').last().simulate('click')
   expect(onAfterNext.calledOnce).toBeTruthy
   expect(onAfterNext.calledWith({})).toBeTruthy
   await expect(onAfterBack.calledAfter(onBeforeNext)).resolves.toBeTruthy
@@ -195,7 +224,7 @@ it('onAfter promises & callbacks called correctly', async () => {
   // show and click back
   track.find(ScrollTrack).node.hideRightArrow()
   track.find(ScrollTrack).node.showLeftArrow()
-  track.find('button').simulate('click')
+  track.find('button').first().simulate('click')
   expect(onAfterBack.calledOnce).toBeTruthy
   expect(onAfterBack.calledWith({})).toBeTruthy
   expect(onAfterBack.calledAfter(onBeforeBack)).toBeTruthy
@@ -220,10 +249,10 @@ it('works without any callbacks passed in', async () => {
 
   // show and click next
   track.find(ScrollTrack).node.showRightArrow()
-  track.find('button').simulate('click')
+  track.find('button').last().simulate('click')
 
   // show and click back
   track.find(ScrollTrack).node.hideRightArrow()
   track.find(ScrollTrack).node.showLeftArrow()
-  track.find('button').simulate('click')
+  track.find('button').first().simulate('click')
 })

--- a/src/components/ScrollTrack/__tests__/__snapshots__/ScrollTrack.spec.js.snap
+++ b/src/components/ScrollTrack/__tests__/__snapshots__/ScrollTrack.spec.js.snap
@@ -14,6 +14,62 @@ exports[`renders ScrollTrack correctly 1`] = `
         }
       }
     >
+      <button
+        aria-label="back"
+        className="rmq-4534e6b"
+        data-radium={true}
+        disabled={undefined}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#43B02A",
+            "border": "0",
+            "borderRadius": "50%",
+            "boxShadow": "0 1px 2px 0 rgba(0, 0, 0, 0.26), 0 1px 4px 0 rgba(0, 0, 0, 0.16)",
+            "color": "#FFFFFF",
+            "display": "none",
+            "height": "48px",
+            "left": 8,
+            "lineHeight": "1",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": "5px",
+            "transition": "background-color 150ms ease-in-out",
+            "width": "48px",
+            "zIndex": 100,
+          }
+        }
+      >
+        <i
+          aria-hidden={true}
+          data-radium={true}
+          onClick={undefined}
+          style={
+            Object {
+              "fontFamily": "ic-icons",
+              "fontSize": "20px",
+              "fontSmoothing": "antialiased",
+              "fontStyle": "normal",
+              "fontVariant": "normal",
+              "fontWeight": "normal",
+              "lineHeight": "1",
+              "osxFontSmoothing": "grayscale",
+              "position": "relative",
+              "speak": "none",
+              "textTransform": "none",
+            }
+          }
+        >
+          
+        </i>
+      </button>
       <div
         className="rmq-16b35912"
         data-radium={true}
@@ -53,6 +109,62 @@ exports[`renders ScrollTrack correctly 1`] = `
           </p>
         </div>
       </div>
+      <button
+        aria-label="next"
+        className="rmq-4534e6b"
+        data-radium={true}
+        disabled={undefined}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#43B02A",
+            "border": "0",
+            "borderRadius": "50%",
+            "boxShadow": "0 1px 2px 0 rgba(0, 0, 0, 0.26), 0 1px 4px 0 rgba(0, 0, 0, 0.16)",
+            "color": "#FFFFFF",
+            "display": "none",
+            "height": "48px",
+            "lineHeight": "1",
+            "position": "absolute",
+            "right": 8,
+            "textAlign": "center",
+            "top": "5px",
+            "transition": "background-color 150ms ease-in-out",
+            "width": "48px",
+            "zIndex": 100,
+          }
+        }
+      >
+        <i
+          aria-hidden={true}
+          data-radium={true}
+          onClick={undefined}
+          style={
+            Object {
+              "fontFamily": "ic-icons",
+              "fontSize": "20px",
+              "fontSmoothing": "antialiased",
+              "fontStyle": "normal",
+              "fontVariant": "normal",
+              "fontWeight": "normal",
+              "lineHeight": "1",
+              "osxFontSmoothing": "grayscale",
+              "position": "relative",
+              "speak": "none",
+              "textTransform": "none",
+            }
+          }
+        >
+          
+        </i>
+      </button>
     </div>
   </div>
   <style
@@ -63,7 +175,8 @@ exports[`renders ScrollTrack correctly 1`] = `
       display: block !important;
       -ms-overflow-style: none !important;
       overflow: -moz-scrollbars-none !important;
-      webkit-overflow-scrolling: touch !important;}}",
+      webkit-overflow-scrolling: touch !important;}}
+      @media (max-width: 767px){ .rmq-4534e6b{display: none !important;}}",
       }
     }
   />
@@ -84,6 +197,62 @@ exports[`renders ScrollTrack with animation props correctly 1`] = `
         }
       }
     >
+      <button
+        aria-label="back"
+        className="rmq-4534e6b"
+        data-radium={true}
+        disabled={undefined}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#43B02A",
+            "border": "0",
+            "borderRadius": "50%",
+            "boxShadow": "0 1px 2px 0 rgba(0, 0, 0, 0.26), 0 1px 4px 0 rgba(0, 0, 0, 0.16)",
+            "color": "#FFFFFF",
+            "display": "none",
+            "height": "48px",
+            "left": 8,
+            "lineHeight": "1",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": "5px",
+            "transition": "background-color 150ms ease-in-out",
+            "width": "48px",
+            "zIndex": 100,
+          }
+        }
+      >
+        <i
+          aria-hidden={true}
+          data-radium={true}
+          onClick={undefined}
+          style={
+            Object {
+              "fontFamily": "ic-icons",
+              "fontSize": "20px",
+              "fontSmoothing": "antialiased",
+              "fontStyle": "normal",
+              "fontVariant": "normal",
+              "fontWeight": "normal",
+              "lineHeight": "1",
+              "osxFontSmoothing": "grayscale",
+              "position": "relative",
+              "speak": "none",
+              "textTransform": "none",
+            }
+          }
+        >
+          
+        </i>
+      </button>
       <div
         className="rmq-16b35912"
         data-radium={true}
@@ -123,6 +292,62 @@ exports[`renders ScrollTrack with animation props correctly 1`] = `
           </p>
         </div>
       </div>
+      <button
+        aria-label="next"
+        className="rmq-4534e6b"
+        data-radium={true}
+        disabled={undefined}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#43B02A",
+            "border": "0",
+            "borderRadius": "50%",
+            "boxShadow": "0 1px 2px 0 rgba(0, 0, 0, 0.26), 0 1px 4px 0 rgba(0, 0, 0, 0.16)",
+            "color": "#FFFFFF",
+            "display": "none",
+            "height": "48px",
+            "lineHeight": "1",
+            "position": "absolute",
+            "right": 8,
+            "textAlign": "center",
+            "top": "5px",
+            "transition": "background-color 150ms ease-in-out",
+            "width": "48px",
+            "zIndex": 100,
+          }
+        }
+      >
+        <i
+          aria-hidden={true}
+          data-radium={true}
+          onClick={undefined}
+          style={
+            Object {
+              "fontFamily": "ic-icons",
+              "fontSize": "20px",
+              "fontSmoothing": "antialiased",
+              "fontStyle": "normal",
+              "fontVariant": "normal",
+              "fontWeight": "normal",
+              "lineHeight": "1",
+              "osxFontSmoothing": "grayscale",
+              "position": "relative",
+              "speak": "none",
+              "textTransform": "none",
+            }
+          }
+        >
+          
+        </i>
+      </button>
     </div>
   </div>
   <style
@@ -133,7 +358,8 @@ exports[`renders ScrollTrack with animation props correctly 1`] = `
       display: block !important;
       -ms-overflow-style: none !important;
       overflow: -moz-scrollbars-none !important;
-      webkit-overflow-scrolling: touch !important;}}",
+      webkit-overflow-scrolling: touch !important;}}
+      @media (max-width: 767px){ .rmq-4534e6b{display: none !important;}}",
       }
     }
   />


### PR DESCRIPTION
We'd like to show a loading state within the buttons during pagination, which we can almost do just through the exposed button style props in ScrollTrack. However, the scroll track does not render elements at all when it hides buttons, so overriding styles in those cases does not work. This fixes that, and gives a very slight performance improvement since elements are not being placed on and off the the DOM.