### PR TITLE
Add jest env to eslintrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
   "env": {
     "browser": true,
-    "es6": true
+    "es6": true,
+    "jest": true
   },
   "extends": [
     "eslint:recommended",


### PR DESCRIPTION
Gets rid of pesky lint errors like "expect/it/describe is not defined".