### PR TITLE
ScrollTrack recalculate node sizes before sliding

### DIFF
--- a/src/components/ScrollTrack/ScrollTrack.js
+++ b/src/components/ScrollTrack/ScrollTrack.js
@@ -195,7 +195,7 @@ class ScrollTrack extends Component {
     onBeforeNext(callbackProps).then(() => {
       // calcuate track values once more, in case children have changed the track size
       const { parentWidth, trackWidth } = this.getNodeWidths()
-      let nextForward = this.state.left - parentWidth
+      const nextForward = this.state.left - parentWidth
 
       this.updateLeftValue({
         left: nextForward,

--- a/src/components/ScrollTrack/ScrollTrack.js
+++ b/src/components/ScrollTrack/ScrollTrack.js
@@ -193,10 +193,21 @@ class ScrollTrack extends Component {
     }
 
     onBeforeNext(callbackProps).then(() => {
+      // calcuate track values once more, in case children have changed the track size
+      const { parentWidth, trackWidth } = this.getNodeWidths()
+      let nextForward = this.state.left - parentWidth
+
       this.updateLeftValue({
         left: nextForward,
         callback: onAfterNext,
-        callbackProps
+        callbackProps: {
+          ...callbackProps,
+          ...{
+            slideTo: nextForward,
+            parentWidth,
+            trackWidth
+          }
+        }
       })
     })
   }

--- a/src/components/ScrollTrack/docs/ScrollTrack.md
+++ b/src/components/ScrollTrack/docs/ScrollTrack.md
@@ -175,6 +175,73 @@ Using callbacks
   </ScrollTrack>
 ```
 
+Doing async pagination:
+
+    initialState = {
+      items: [
+        { id: 1 },
+        { id: 2 },
+        { id: 3 },
+        { id: 4 },
+        { id: 5 },
+        { id: 6 },
+        { id: 7 },
+        { id: 8 },
+        { id: 9 },
+        { id: 10 },
+        { id: 11 },
+        { id: 12 },
+        { id: 13 },
+        { id: 14 },
+        { id: 15 },
+        { id: 16 },
+        { id: 17 },
+        { id: 18 },
+        { id: 19 }
+      ]
+    };
+
+
+    const itemsToAddLater = (itemsCount) => {
+      // generate more items
+      const arr = []
+      let i = 0
+      while (i <= itemsCount) {
+        i += 1
+        arr.push({ id: itemsCount + i })
+      }
+
+      return arr
+    };
+
+    <ScrollTrack
+      styles={{ Track: { height: '56px', padding: '10px 0' }, RightArrow: { top: '6px' }}}
+      onBeforeNext={({atStart, atEnd, slideTo, parentWidth, trackWidth}) => {
+          return new Promise((resolve, reject) => {
+            setTimeout(() => {
+                // add items 1 second later, then resolve
+                setState({items: state.items.concat(itemsToAddLater(state.items.length))}, resolve)
+            }, 1000)
+          })
+      }}
+    >
+      <div>
+        { state.items.map(item =>
+          <Icon
+            name="cart"
+            style={{
+              ...styles,
+              ...{
+                backgroundColor: item.id % 2 != 0 ? '#eee' : '#43B02A',
+                color: item.id % 2 != 0 ? '#43B02A' : '#eee'
+              }
+            }}
+            key={`pagination_item_${item.id}`}
+          />
+        )}
+      </div>
+    </ScrollTrack>
+
 Using custom next and back button content
 
     <ScrollTrack


### PR DESCRIPTION
Recomputing slide track node widths once more after `onBeforeNext` callback in case the children have changed the track width since last compute. This is especially important for async pagination.