### PR TITLE
Grid support for IE

### DIFF
--- a/src/components/Grid/Column.js
+++ b/src/components/Grid/Column.js
@@ -2,8 +2,68 @@ import React      from 'react'
 import PropTypes  from 'prop-types'
 import Radium from 'radium'
 import responsive from '../../styles/responsive'
+import { supportsCSSGrid } from '../../utils/detectFeature'
+
+const { columnWidth } = responsive
+
+const getLecacySizedStyles = sizes => {
+  return {
+    display: 'inline-block',
+
+    [responsive.xs]: {
+      display: 'block',
+      width: '100%'
+    },
+
+    [responsive.sm]: {
+      width: `${(sizes.sm || 1) * columnWidth}px`
+    },
+
+    [responsive.md]: {
+      width: `${(sizes.md || sizes.sm || 1) * columnWidth}px`
+    },
+
+    [responsive.mdLg]: {
+      width: `${(sizes.mdLg || sizes.md || sizes.sm || 1) * columnWidth}px`
+    },
+
+    [responsive.lg]: {
+      width: `${(sizes.lg || sizes.mdLg || sizes.md || sizes.sm || 1) * columnWidth}px`
+    },
+
+    [responsive.xl]: {
+      width: `${(sizes.xl || sizes.lg || sizes.mdLg || sizes.md || sizes.sm || 1) * columnWidth}px`
+    }
+  }
+}
+
+const getSizedStyles = sizes => {
+  return {
+    [responsive.sm]: {
+      gridColumn: `span ${sizes.sm || 1}`
+    },
+
+    [responsive.md]: {
+      gridColumn: `span ${sizes.md || sizes.sm || 1}`
+    },
+
+    [responsive.mdLg]: {
+      gridColumn: `span ${sizes.mdLg || sizes.md || sizes.sm || 1}`
+    },
+
+    [responsive.lg]: {
+      gridColumn: `span ${sizes.lg || sizes.mdLg || sizes.md || sizes.sm || 1}`
+    },
+
+    [responsive.xl]: {
+      gridColumn: `span ${sizes.xl || sizes.lg || sizes.mdLg || sizes.md || sizes.sm || 1}`
+    }
+  }
+}
 
 const Column = props => {
+  const { sizes } = props
+
   if (props.sizes.xs) {
     console.warn('xs size prop passed to Column!',
       'This will be ignored. All columns at xs screen size are full-width. ',
@@ -12,34 +72,12 @@ const Column = props => {
     )
   }
 
-  const getSizedStyles = () => {
-    return {
-      [responsive.sm]: {
-        gridColumn: `span ${props.sizes.sm || 1}`
-      },
-
-      [responsive.md]: {
-        gridColumn: `span ${props.sizes.md || props.sizes.sm || 1}`
-      },
-
-      [responsive.mdLg]: {
-        gridColumn: `span ${props.sizes.mdLg || props.sizes.md || props.sizes.sm || 1}`
-      },
-
-      [responsive.lg]: {
-        gridColumn: `span ${props.sizes.lg || props.sizes.mdLg || props.sizes.md || props.sizes.sm || 1}`
-      },
-
-      [responsive.xl]: {
-        gridColumn: `span ${props.sizes.xl || props.sizes.lg || props.sizes.mdLg || props.sizes.md || props.sizes.sm || 1}`
-      }
-    }
-  }
+  const styles = supportsCSSGrid() ? getSizedStyles(sizes) : getLecacySizedStyles(sizes)
 
   return (
     <div
       style={[
-        getSizedStyles(),
+        styles,
         props.styles
       ]}
     >

--- a/src/components/Grid/Row.js
+++ b/src/components/Grid/Row.js
@@ -63,15 +63,13 @@ const styles = {
 const getMaxColumnsStyles = props => {
   const { maxColumns } = props
 
-  const override = supportsCSSGrid()
-  ? {
-      gridTemplateColumns: `repeat(${maxColumns}, ${responsive.columnWidth}px)`,
-      justifyContent: 'center'
-    }
-  : {
-      width: `${maxColumns * responsive.columnWidth}px`,
-      margin: '0 auto'
-    }
+  const override = supportsCSSGrid() ? {
+    gridTemplateColumns: `repeat(${maxColumns}, ${responsive.columnWidth}px)`,
+    justifyContent: 'center'
+  } : {
+    width: `${maxColumns * responsive.columnWidth}px`,
+    margin: '0 auto'
+  }
 
   if (maxColumns <= 6) {
     return {

--- a/src/components/Grid/Row.js
+++ b/src/components/Grid/Row.js
@@ -2,6 +2,32 @@ import React      from 'react'
 import PropTypes  from 'prop-types'
 import Radium from 'radium'
 import responsive from '../../styles/responsive'
+import { supportsCSSGrid } from '../../utils/detectFeature'
+
+// used for browsers without css grid support
+const legacyStyles = {
+  display: 'block',
+
+  [responsive.sm]: {
+    width: `${6 * responsive.columnWidth}px`
+  },
+
+  [responsive.md]: {
+    width: `${8 * responsive.columnWidth}px`
+  },
+
+  [responsive.mdLg]: {
+    width: `${10 * responsive.columnWidth}px`
+  },
+
+  [responsive.lg]: {
+    width: `${12 * responsive.columnWidth}px`
+  },
+
+  [responsive.xl]: {
+    width: `${14 * responsive.columnWidth}px`
+  }
+}
 
 const styles = {
   [responsive.xs]: {
@@ -34,87 +60,94 @@ const styles = {
   }
 }
 
-const Row = props => {
-  const getMaxColumnsStyles = () => {
-    const { maxColumns } = props
+const getMaxColumnsStyles = props => {
+  const { maxColumns } = props
 
-    const override = {
+  const override = supportsCSSGrid()
+  ? {
       gridTemplateColumns: `repeat(${maxColumns}, ${responsive.columnWidth}px)`,
       justifyContent: 'center'
     }
-
-    if (maxColumns <= 6) {
-      return {
-        [responsive.md]: override,
-        [responsive.mdLg]: override,
-        [responsive.lg]: override,
-        [responsive.xl]: override
-      }
-    } else if (maxColumns <= 8) {
-      return {
-        [responsive.mdLg]: override,
-        [responsive.lg]: override,
-        [responsive.xl]: override
-      }
-    } else if (maxColumns <= 10) {
-      return {
-        [responsive.lg]:override,
-        [responsive.xl]: override
-      }
-    } else if (maxColumns <= 12) {
-      return {
-        [responsive.xl]: override
-      }
+  : {
+      width: `${maxColumns * responsive.columnWidth}px`,
+      margin: '0 auto'
     }
 
-    return {}
-  }
-
-  const getFullWidthStyles = () => {
-    const { screenWidths } = responsive
-    if (!props.forceFullPage) { return {} }
-
+  if (maxColumns <= 6) {
     return {
-      width: '100vw',
-      justifyContent: 'center',
-      [responsive.xs]: {
-        display: 'block',
-        margin: `0 calc(-1 * (100vw - ${screenWidths.xs}px) / 2)`
-      },
-
-      [responsive.sm]: {
-        display: 'block',
-        margin: `0 calc(-1 * (100vw - ${screenWidths.sm}px) / 2)`
-      },
-
-      [responsive.md]: {
-        display: 'block',
-        margin: `0 calc(-1 * (100vw - ${screenWidths.md}px) / 2)`
-      },
-
-      [responsive.mdLg]: {
-        display: 'block',
-        margin: `0 calc(-1 * (100vw - ${screenWidths.mdLg}px) / 2)`
-      },
-
-      [responsive.lg]: {
-        display: 'block',
-        margin: `0 calc(-1 * (100vw - ${screenWidths.lg}px) / 2)`
-      },
-
-      [responsive.xl]: {
-        display: 'block',
-        margin: `0 calc(-1 * (100vw - ${screenWidths.xl}px) / 2)`
-      }
+      [responsive.md]: override,
+      [responsive.mdLg]: override,
+      [responsive.lg]: override,
+      [responsive.xl]: override
+    }
+  } else if (maxColumns <= 8) {
+    return {
+      [responsive.mdLg]: override,
+      [responsive.lg]: override,
+      [responsive.xl]: override
+    }
+  } else if (maxColumns <= 10) {
+    return {
+      [responsive.lg]:override,
+      [responsive.xl]: override
+    }
+  } else if (maxColumns <= 12) {
+    return {
+      [responsive.xl]: override
     }
   }
+
+  return {}
+}
+
+const getFullWidthStyles = props => {
+  const { screenWidths } = responsive
+  if (!props.forceFullPage) { return {} }
+
+  return {
+    width: '100vw',
+    justifyContent: 'center',
+    [responsive.xs]: {
+      display: 'block',
+      margin: `0 calc(-1 * (100vw - ${screenWidths.xs}px) / 2)`
+    },
+
+    [responsive.sm]: {
+      display: 'block',
+      margin: `0 calc(-1 * (100vw - ${screenWidths.sm}px) / 2)`
+    },
+
+    [responsive.md]: {
+      display: 'block',
+      margin: `0 calc(-1 * (100vw - ${screenWidths.md}px) / 2)`
+    },
+
+    [responsive.mdLg]: {
+      display: 'block',
+      margin: `0 calc(-1 * (100vw - ${screenWidths.mdLg}px) / 2)`
+    },
+
+    [responsive.lg]: {
+      display: 'block',
+      margin: `0 calc(-1 * (100vw - ${screenWidths.lg}px) / 2)`
+    },
+
+    [responsive.xl]: {
+      display: 'block',
+      margin: `0 calc(-1 * (100vw - ${screenWidths.xl}px) / 2)`
+    }
+  }
+}
+
+const Row = props => {
+  const componentStyles = supportsCSSGrid() ? styles : legacyStyles
 
   return (
     <div
       style={[
-        styles,
-        getMaxColumnsStyles(),
-        getFullWidthStyles(),
+        componentStyles,
+        getMaxColumnsStyles(props),
+        getFullWidthStyles(props),
         props.styles
       ]}
     >

--- a/src/components/Grid/docs/Grid.md
+++ b/src/components/Grid/docs/Grid.md
@@ -1,65 +1,65 @@
 Grid example:
 
-    columnStyles = { backgroundColor: '#43B02A', border: '1px solid white', textAlign: 'center' };
+    columnStyles = { height: '56px', margin: 0, lineHeight: '56px', backgroundColor: '#43B02A', border: '1px solid white', textAlign: 'center' };
     <div>
       <Grid styles={{ backgroundColor: '#eee' }}>
         <Row styles={{ marginBottom: '20px' }}>
-          <Column sizes={{ sm: 1 }} styles={columnStyles}><p>One</p></Column>
-          <Column sizes={{ sm: 1 }} styles={columnStyles}><p>Two</p></Column>
-          <Column sizes={{ sm: 1 }} styles={columnStyles}><p>Three</p></Column>
-          <Column sizes={{ sm: 1 }} styles={columnStyles}><p>Four</p></Column>
-          <Column sizes={{ sm: 1 }} styles={columnStyles}><p>Five</p></Column>
-          <Column sizes={{ sm: 1 }} styles={columnStyles}><p>Six</p></Column>
-          <Column sizes={{ sm: 1 }} styles={columnStyles}><p>Seven</p></Column>
-          <Column sizes={{ sm: 1 }} styles={columnStyles}><p>Eight</p></Column>
-          <Column sizes={{ sm: 1 }} styles={columnStyles}><p>Nine</p></Column>
-          <Column sizes={{ sm: 1 }} styles={columnStyles}><p>Ten</p></Column>
-          <Column sizes={{ sm: 1 }} styles={columnStyles}><p>Eleven</p></Column>
-          <Column sizes={{ sm: 1 }} styles={columnStyles}><p>Twelve</p></Column>
-          <Column sizes={{ sm: 1 }} styles={columnStyles}><p>Thirteen</p></Column>
-          <Column sizes={{ sm: 1 }} styles={columnStyles}><p>Fourteen</p></Column>
+          <Column sizes={{ sm: 1 }}><p style={columnStyles}>One</p></Column>
+          <Column sizes={{ sm: 1 }}><p style={columnStyles}>Two</p></Column>
+          <Column sizes={{ sm: 1 }}><p style={columnStyles}>Three</p></Column>
+          <Column sizes={{ sm: 1 }}><p style={columnStyles}>Four</p></Column>
+          <Column sizes={{ sm: 1 }}><p style={columnStyles}>Five</p></Column>
+          <Column sizes={{ sm: 1 }}><p style={columnStyles}>Six</p></Column>
+          <Column sizes={{ sm: 1 }}><p style={columnStyles}>Seven</p></Column>
+          <Column sizes={{ sm: 1 }}><p style={columnStyles}>Eight</p></Column>
+          <Column sizes={{ sm: 1 }}><p style={columnStyles}>Nine</p></Column>
+          <Column sizes={{ sm: 1 }}><p style={columnStyles}>Ten</p></Column>
+          <Column sizes={{ sm: 1 }}><p style={columnStyles}>Eleven</p></Column>
+          <Column sizes={{ sm: 1 }}><p style={columnStyles}>Twelve</p></Column>
+          <Column sizes={{ sm: 1 }}><p style={columnStyles}>Thirteen</p></Column>
+          <Column sizes={{ sm: 1 }}><p style={columnStyles}>Fourteen</p></Column>
         </Row>
         <Row styles={{ marginBottom: '20px' }}>
-          <Column sizes={{ sm: 2 }} styles={columnStyles}><p>One</p></Column>
-          <Column sizes={{ sm: 2 }} styles={columnStyles}><p>Two</p></Column>
-          <Column sizes={{ sm: 2 }} styles={columnStyles}><p>Three</p></Column>
-          <Column sizes={{ sm: 2 }} styles={columnStyles}><p>Four</p></Column>
-          <Column sizes={{ sm: 2 }} styles={columnStyles}><p>Five</p></Column>
-          <Column sizes={{ sm: 2 }} styles={columnStyles}><p>Six</p></Column>
-          <Column sizes={{ sm: 2 }} styles={columnStyles}><p>Seven</p></Column>
+          <Column sizes={{ sm: 2 }}><p style={columnStyles}>One</p></Column>
+          <Column sizes={{ sm: 2 }}><p style={columnStyles}>Two</p></Column>
+          <Column sizes={{ sm: 2 }}><p style={columnStyles}>Three</p></Column>
+          <Column sizes={{ sm: 2 }}><p style={columnStyles}>Four</p></Column>
+          <Column sizes={{ sm: 2 }}><p style={columnStyles}>Five</p></Column>
+          <Column sizes={{ sm: 2 }}><p style={columnStyles}>Six</p></Column>
+          <Column sizes={{ sm: 2 }}><p style={columnStyles}>Seven</p></Column>
         </Row>
         <Row styles={{ marginBottom: '20px' }}>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>One</p></Column>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>Two</p></Column>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>Three</p></Column>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>Four</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>One</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>Two</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>Three</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>Four</p></Column>
         </Row>
         <Row styles={{ marginBottom: '20px' }}>
-          <Column sizes={{ sm: 4 }} styles={columnStyles}><p>One</p></Column>
-          <Column sizes={{ sm: 4 }} styles={columnStyles}><p>Two</p></Column>
-          <Column sizes={{ sm: 4 }} styles={columnStyles}><p>Two</p></Column>
+          <Column sizes={{ sm: 4 }}><p style={columnStyles}>One</p></Column>
+          <Column sizes={{ sm: 4 }}><p style={columnStyles}>Two</p></Column>
+          <Column sizes={{ sm: 4 }}><p style={columnStyles}>Two</p></Column>
         </Row>
         <Row styles={{ marginBottom: '20px' }}>
-          <Column sizes={{ sm: 2, md: 2, lg: 4, xl: 5}} styles={columnStyles}><p>One</p></Column>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>Two</p></Column>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>Three</p></Column>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>Four</p></Column>
+          <Column sizes={{ sm: 2, md: 2, lg: 4, xl: 5}}><p style={columnStyles}>One</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>Two</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>Three</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>Four</p></Column>
         </Row>
         <Row styles={{ marginBottom: '20px' }} maxColumns={10}>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>One</p></Column>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>Two</p></Column>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>Three</p></Column>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>Four</p></Column>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>Five</p></Column>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>Six</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>One</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>Two</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>Three</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>Four</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>Five</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>Six</p></Column>
         </Row>
         <Row styles={{ marginBottom: '20px' }} maxColumns={6}>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>One</p></Column>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>Two</p></Column>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>Three</p></Column>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>Four</p></Column>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>Five</p></Column>
-          <Column sizes={{ sm: 3 }} styles={columnStyles}><p>Six</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>One</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>Two</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>Three</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>Four</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>Five</p></Column>
+          <Column sizes={{ sm: 3 }}><p style={columnStyles}>Six</p></Column>
         </Row>
       </Grid>
     </div>

--- a/src/utils/detectFeature.js
+++ b/src/utils/detectFeature.js
@@ -3,9 +3,9 @@ import _ from 'underscore'
 export const supportsCSSGrid = _.memoize(() => {
   const userAgent = (navigator && navigator.userAgent) || ''
   const isTestEnv = userAgent.match(/(Node.js|jsdom)/)
+  const isNodeEnv = typeof window === 'undefined'
 
-  // NOTE: server-side rendering end test environemnt cases ignored during this step
-  if (isTestEnv || !window || !window.document || !window.document) { return true }
+  if (isTestEnv || isNodeEnv) { return true }
 
   const elm = document.createElement('div')
 

--- a/src/utils/detectFeature.js
+++ b/src/utils/detectFeature.js
@@ -1,10 +1,15 @@
 import _ from 'underscore'
 
 export const supportsCSSGrid = _.memoize(() => {
-  // NOTE: server-side rendering cases ignored during this step
-  if (!window || !window.document || !window.document.body) { return true }
+  const userAgent = (navigator && navigator.userAgent) || ''
+  const isTestEnv = userAgent.match(/(Node.js|jsdom)/)
 
-  return window.document.body.style['grid-template-rows'] !== undefined
+  // NOTE: server-side rendering end test environemnt cases ignored during this step
+  if (isTestEnv || !window || !window.document || !window.document) { return true }
+
+  const elm = document.createElement('div')
+
+  return elm.style['grid-template-rows'] !== undefined
 })
 
 export default { supportsCSSGrid }

--- a/src/utils/detectFeature.js
+++ b/src/utils/detectFeature.js
@@ -1,0 +1,10 @@
+import _ from 'underscore'
+
+export const supportsCSSGrid = _.memoize(() => {
+  // NOTE: server-side rendering cases ignored during this step
+  if (!window || !window.document || !window.document.body) { return true }
+
+  return window.document.body.style['grid-template-rows'] !== undefined
+})
+
+export default { supportsCSSGrid }


### PR DESCRIPTION
IE support for css grid is lacking, most importantly the support for auto positioning columns. This pr adds a feature detector for css grid as well as fallback styles for when it is unsupported. This brings support for our grid back to at least ie10, though I think we probably will only eventually aim for ie11+ support within Snacks.