### PR TITLE
Making Radio, RadioGroup and Chebox compatible with Safari and IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "react": "^15.5.0",
     "react-dom": "^15.5.0",
     "react-styleguidist": "^6.2.5",
-    "react-svg-loader": "^2.1.0",
     "react-test-renderer": "^15.5.0",
     "react-transition-group": "^2.2.1",
     "sinon": "^2.3.8",
+    "svg-sprite-loader": "^3.6.2",
     "underscore": "^1.8.3",
     "webpack": "^3.8.1"
   },

--- a/src/base/RadioCheckboxBase.js
+++ b/src/base/RadioCheckboxBase.js
@@ -44,12 +44,22 @@ function imgValidator (props, propName) {
   }
 }
 
+function renderSvg(svgSprite) {
+  return (
+    <div style={STYLE.image}>
+      <svg viewBox={svgSprite.viewBox}>
+        <use xlinkHref={`sprite.svg#${svgSprite.id}`} />
+      </svg>
+    </div>
+  )
+}
+
 class RadioCheckboxBase extends React.PureComponent {
   static propTypes = {
     aria          : PropTypes.shape({
       label         :PropTypes.string,
     }),
-    bkgSvg        : PropTypes.shape({
+    bkgSvgSprites : PropTypes.shape({
       base          : imgValidator,
       selected      : imgValidator,
       disabled      : imgValidator,
@@ -100,16 +110,16 @@ class RadioCheckboxBase extends React.PureComponent {
   }
 
   renderInputBtn() {
-    let BkgSvg
-    const { aria, bkgSvg, btnType, isDisabled, id, style, value } = this.props
+    let svgSprite
+    const { aria, bkgSvgSprites, btnType, isDisabled, id, style, value } = this.props
     const { isSelected } = this.state
 
-    if (isDisabled) { BkgSvg = bkgSvg.disabled }
-    else { BkgSvg = isSelected ? bkgSvg.selected : bkgSvg.base }
+    if (isDisabled) { svgSprite = bkgSvgSprites.disabled }
+    else { svgSprite = isSelected ? bkgSvgSprites.selected : bkgSvgSprites.base }
 
     return (
       <div style={{...STYLE.button, ...style.button}}>
-        <BkgSvg />
+        {renderSvg(svgSprite)}
         <input
           id={id}
           type={btnType}

--- a/src/components/Buttons/Checkbox.js
+++ b/src/components/Buttons/Checkbox.js
@@ -12,7 +12,13 @@ const BKG_SVG_SPRITES = {
 }
 
 const Checkbox = (props) => {
-  return <RadioCheckboxBase btnType='checkbox' bkgSvgSprites={BKG_SVG_SPRITES} {...props} />
+  return (
+    <RadioCheckboxBase
+      btnType='checkbox'
+      bkgSvgSprites={BKG_SVG_SPRITES}
+      {...props}
+    />
+  )
 }
 
 Checkbox.propTypes = {

--- a/src/components/Buttons/Checkbox.js
+++ b/src/components/Buttons/Checkbox.js
@@ -5,14 +5,14 @@ import bkgSvgBase from '../../assets/checkboxBase.svg'
 import bkgSvgSelected from '../../assets/checkboxSelected.svg'
 import bkgSvgDisabled from '../../assets/checkboxDisabled.svg'
 
-const BKG_SVGS = {
-  base: bkgSvgBase,
-  selected: bkgSvgSelected,
-  disabled: bkgSvgDisabled,
+const BKG_SVG_SPRITES = {
+  base:       bkgSvgBase,
+  selected:   bkgSvgSelected,
+  disabled:   bkgSvgDisabled,
 }
 
 const Checkbox = (props) => {
-  return <RadioCheckboxBase btnType='checkbox' bkgSvg={BKG_SVGS} {...props} />
+  return <RadioCheckboxBase btnType='checkbox' bkgSvgSprites={BKG_SVG_SPRITES} {...props} />
 }
 
 Checkbox.propTypes = {

--- a/src/components/Buttons/Radio.js
+++ b/src/components/Buttons/Radio.js
@@ -5,14 +5,14 @@ import bkgSvgBase from '../../assets/radioBase.svg'
 import bkgSvgSelected from '../../assets/radioSelected.svg'
 import bkgSvgDisabled from '../../assets/radioDisabled.svg'
 
-const BKG_SVGS = {
-  base: bkgSvgBase,
-  selected: bkgSvgSelected,
-  disabled: bkgSvgDisabled,
+const BKG_SVG_SPRITES = {
+  base:       bkgSvgBase,
+  selected:   bkgSvgSelected,
+  disabled:   bkgSvgDisabled,
 }
 
 const Radio = (props) => {
-  return <RadioCheckboxBase btnType='radio' bkgSvg={BKG_SVGS} {...props} />
+  return <RadioCheckboxBase btnType='radio' bkgSvgSprites={BKG_SVG_SPRITES} {...props} />
 }
 
 Radio.propTypes = {

--- a/src/components/Buttons/Radio.js
+++ b/src/components/Buttons/Radio.js
@@ -12,7 +12,13 @@ const BKG_SVG_SPRITES = {
 }
 
 const Radio = (props) => {
-  return <RadioCheckboxBase btnType='radio' bkgSvgSprites={BKG_SVG_SPRITES} {...props} />
+  return (
+    <RadioCheckboxBase
+      btnType='radio'
+      bkgSvgSprites={BKG_SVG_SPRITES}
+      {...props}
+    />
+  )
 }
 
 Radio.propTypes = {

--- a/src/components/Buttons/__tests__/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/Buttons/__tests__/__snapshots__/Checkbox.spec.js.snap
@@ -17,7 +17,23 @@ exports[`Checkbox generates a label if a child prop of text is supplied 1`] = `
       }
     }
   >
-    <test-file-stub />
+    <div
+      data-radium={true}
+      style={
+        Object {
+          "height": 22,
+          "width": 22,
+        }
+      }
+    >
+      <svg
+        viewBox={undefined}
+      >
+        <use
+          xlinkHref="sprite.svg#undefined"
+        />
+      </svg>
+    </div>
     <input
       aria-label={undefined}
       checked={false}
@@ -75,7 +91,23 @@ exports[`Checkbox incorporates user style if passed 1`] = `
       }
     }
   >
-    <test-file-stub />
+    <div
+      data-radium={true}
+      style={
+        Object {
+          "height": 22,
+          "width": 22,
+        }
+      }
+    >
+      <svg
+        viewBox={undefined}
+      >
+        <use
+          xlinkHref="sprite.svg#undefined"
+        />
+      </svg>
+    </div>
     <input
       aria-label={undefined}
       checked={false}
@@ -132,7 +164,23 @@ exports[`Checkbox incorporates user style if passed 2`] = `
       }
     }
   >
-    <test-file-stub />
+    <div
+      data-radium={true}
+      style={
+        Object {
+          "height": 22,
+          "width": 22,
+        }
+      }
+    >
+      <svg
+        viewBox={undefined}
+      >
+        <use
+          xlinkHref="sprite.svg#undefined"
+        />
+      </svg>
+    </div>
     <input
       aria-label={undefined}
       checked={false}
@@ -180,7 +228,23 @@ exports[`Checkbox renders the correct button type 1`] = `
     }
   }
 >
-  <test-file-stub />
+  <div
+    data-radium={true}
+    style={
+      Object {
+        "height": 22,
+        "width": 22,
+      }
+    }
+  >
+    <svg
+      viewBox={undefined}
+    >
+      <use
+        xlinkHref="sprite.svg#undefined"
+      />
+    </svg>
+  </div>
   <input
     aria-label={undefined}
     checked={false}
@@ -216,7 +280,23 @@ exports[`Checkbox renders the correct selected state 1`] = `
     }
   }
 >
-  <test-file-stub />
+  <div
+    data-radium={true}
+    style={
+      Object {
+        "height": 22,
+        "width": 22,
+      }
+    }
+  >
+    <svg
+      viewBox={undefined}
+    >
+      <use
+        xlinkHref="sprite.svg#undefined"
+      />
+    </svg>
+  </div>
   <input
     aria-label={undefined}
     checked={false}
@@ -252,7 +332,23 @@ exports[`Checkbox renders the correct selected state 2`] = `
     }
   }
 >
-  <test-file-stub />
+  <div
+    data-radium={true}
+    style={
+      Object {
+        "height": 22,
+        "width": 22,
+      }
+    }
+  >
+    <svg
+      viewBox={undefined}
+    >
+      <use
+        xlinkHref="sprite.svg#undefined"
+      />
+    </svg>
+  </div>
   <input
     aria-label={undefined}
     checked={true}
@@ -288,7 +384,23 @@ exports[`Checkbox renders the correct selected state 3`] = `
     }
   }
 >
-  <test-file-stub />
+  <div
+    data-radium={true}
+    style={
+      Object {
+        "height": 22,
+        "width": 22,
+      }
+    }
+  >
+    <svg
+      viewBox={undefined}
+    >
+      <use
+        xlinkHref="sprite.svg#undefined"
+      />
+    </svg>
+  </div>
   <input
     aria-label={undefined}
     checked={false}

--- a/src/components/Buttons/__tests__/__snapshots__/Radio.spec.js.snap
+++ b/src/components/Buttons/__tests__/__snapshots__/Radio.spec.js.snap
@@ -17,7 +17,23 @@ exports[`Radio generates a label if a child prop of text is supplied 1`] = `
       }
     }
   >
-    <test-file-stub />
+    <div
+      data-radium={true}
+      style={
+        Object {
+          "height": 22,
+          "width": 22,
+        }
+      }
+    >
+      <svg
+        viewBox={undefined}
+      >
+        <use
+          xlinkHref="sprite.svg#undefined"
+        />
+      </svg>
+    </div>
     <input
       aria-label={undefined}
       checked={false}
@@ -75,7 +91,23 @@ exports[`Radio incorporates user styles if passed 1`] = `
       }
     }
   >
-    <test-file-stub />
+    <div
+      data-radium={true}
+      style={
+        Object {
+          "height": 22,
+          "width": 22,
+        }
+      }
+    >
+      <svg
+        viewBox={undefined}
+      >
+        <use
+          xlinkHref="sprite.svg#undefined"
+        />
+      </svg>
+    </div>
     <input
       aria-label={undefined}
       checked={false}
@@ -132,7 +164,23 @@ exports[`Radio incorporates user styles if passed 2`] = `
       }
     }
   >
-    <test-file-stub />
+    <div
+      data-radium={true}
+      style={
+        Object {
+          "height": 22,
+          "width": 22,
+        }
+      }
+    >
+      <svg
+        viewBox={undefined}
+      >
+        <use
+          xlinkHref="sprite.svg#undefined"
+        />
+      </svg>
+    </div>
     <input
       aria-label={undefined}
       checked={false}
@@ -180,7 +228,23 @@ exports[`Radio renders the correct button type 1`] = `
     }
   }
 >
-  <test-file-stub />
+  <div
+    data-radium={true}
+    style={
+      Object {
+        "height": 22,
+        "width": 22,
+      }
+    }
+  >
+    <svg
+      viewBox={undefined}
+    >
+      <use
+        xlinkHref="sprite.svg#undefined"
+      />
+    </svg>
+  </div>
   <input
     aria-label={undefined}
     checked={false}
@@ -216,7 +280,23 @@ exports[`Radio renders the correct selected state 1`] = `
     }
   }
 >
-  <test-file-stub />
+  <div
+    data-radium={true}
+    style={
+      Object {
+        "height": 22,
+        "width": 22,
+      }
+    }
+  >
+    <svg
+      viewBox={undefined}
+    >
+      <use
+        xlinkHref="sprite.svg#undefined"
+      />
+    </svg>
+  </div>
   <input
     aria-label={undefined}
     checked={false}
@@ -252,7 +332,23 @@ exports[`Radio renders the correct selected state 2`] = `
     }
   }
 >
-  <test-file-stub />
+  <div
+    data-radium={true}
+    style={
+      Object {
+        "height": 22,
+        "width": 22,
+      }
+    }
+  >
+    <svg
+      viewBox={undefined}
+    >
+      <use
+        xlinkHref="sprite.svg#undefined"
+      />
+    </svg>
+  </div>
   <input
     aria-label={undefined}
     checked={true}
@@ -288,7 +384,23 @@ exports[`Radio renders the correct selected state 3`] = `
     }
   }
 >
-  <test-file-stub />
+  <div
+    data-radium={true}
+    style={
+      Object {
+        "height": 22,
+        "width": 22,
+      }
+    }
+  >
+    <svg
+      viewBox={undefined}
+    >
+      <use
+        xlinkHref="sprite.svg#undefined"
+      />
+    </svg>
+  </div>
   <input
     aria-label={undefined}
     checked={false}

--- a/src/components/Buttons/docs/Checkbox.md
+++ b/src/components/Buttons/docs/Checkbox.md
@@ -1,6 +1,6 @@
 This component outputs a checkbox with an optional label.
 
-You can define whether the button starts in the pressed on unpressed state through the `isSelected` prop. In addition, you can change the checked/unchecked state at any moment after the mount state by redifining the prop `isSelected`.
+You can define whether the button starts in the pressed on unpressed state through the `isSelected` prop. In addition, you can change the selected/unselected state at any moment after the mount state by redifining the prop `isSelected`.
 
 ### Label
 Associating a label to every radio button is very important for accessibility purposes. There are two ways to do it. The easiest is to enclose the text with the component: `<Checkbox>My label</Checkbox>`. The other option is to associate a label yourself:
@@ -37,7 +37,7 @@ You can pass a callback through the `onChange` prop:
 
 ```js
 function onChange(event, props) {
-  alert(`This button is ${props.isSelected ? '' : 'not '}checked`)
+  alert(`This button is ${props.isSelected ? '' : 'not '}selected`)
 }
 
 <Checkbox id="checkbox4" onChange={onChange}>Click me!</Checkbox>

--- a/src/components/Buttons/docs/Radio.md
+++ b/src/components/Buttons/docs/Radio.md
@@ -1,6 +1,6 @@
 This component outputs a radio button with an optional label.
 
-You can define whether the button starts in the pressed on unpressed state through the `isSelected` prop. In addition, you can change the checked/unchecked state at any moment after the mount state by redifining the prop `isSelected`.
+You can define whether the button starts in the pressed on unpressed state through the `isSelected` prop. In addition, you can change the selected/unselected state at any moment after the mount state by redifining the prop `isSelected`.
 
 **Note:** Radio buttons are not supposed to be unselected once pressed. If you need that behavior, a button or a checkbox is a better solution.
 
@@ -18,7 +18,7 @@ Associating a label to every radio button is very important for accessibility pu
 ```
 
 ### Groups
-To create a radio group where only one button can be checked [see here](#radiogroup).
+To create a radio group where only one button can be selected [see here](#radiogroup).
 
 ### Styling
 You can pass an object to the `style` prop for styling the label, radio button and wrap element using Radium's structure:
@@ -42,7 +42,7 @@ You can pass a callback through the `onChange` prop:
 
 ```js
 function onChange(event, props) {
-  alert(`This button is ${props.isSelected ? '' : 'not '}checked`)
+  alert(`This button is ${props.isSelected ? '' : 'not '}selected`)
 }
 
 <Radio id="radio4" onChange={onChange}>Click me!</Radio>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,12 @@
 const path = require('path')
 const webpack = require("webpack")
+const SpriteLoaderPlugin = require('svg-sprite-loader/plugin')
 
 module.exports = {
   module: {
    loaders: [
      { test: /\.js$/, loaders: ['babel-loader'], exclude: /node_modules/ },
-     { test: /\.svg$/, loader: "react-svg-loader", exclude: /node_modules/ }
+     { test: /\.svg$/, loader: 'svg-sprite-loader', exclude: /node_modules/, options: { extract: true } },
    ]
   },
   entry: {
@@ -21,6 +22,9 @@ module.exports = {
       styles: path.resolve(__dirname, 'src/styles'),
     }
   },
+  plugins: [
+    new SpriteLoaderPlugin()
+  ],
   externals: {
     'react': 'react',
     'react-dom': 'react-dom',

--- a/yarn.lock
+++ b/yarn.lock
@@ -424,30 +424,6 @@ babel-core@^6.0.0, babel-core@^6.21.0, babel-core@^6.24.1:
     slash "^1.0.0"
     source-map "^0.5.0"
 
-babel-core@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-generator "^6.26.0"
-    babel-helpers "^6.24.1"
-    babel-messages "^6.23.0"
-    babel-register "^6.26.0"
-    babel-runtime "^6.26.0"
-    babel-template "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    convert-source-map "^1.5.0"
-    debug "^2.6.8"
-    json5 "^0.5.1"
-    lodash "^4.17.4"
-    minimatch "^3.0.4"
-    path-is-absolute "^1.0.1"
-    private "^0.1.7"
-    slash "^1.0.0"
-    source-map "^0.5.6"
-
 babel-eslint@^7.2.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
@@ -468,19 +444,6 @@ babel-generator@^6.18.0, babel-generator@^6.25.0:
     jsesc "^1.3.0"
     lodash "^4.2.0"
     source-map "^0.5.0"
-    trim-right "^1.0.1"
-
-babel-generator@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.0.tgz#ac1ae20070b79f6e3ca1d3269613053774f20dc5"
-  dependencies:
-    babel-messages "^6.23.0"
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    detect-indent "^4.0.0"
-    jsesc "^1.3.0"
-    lodash "^4.17.4"
-    source-map "^0.5.6"
     trim-right "^1.0.1"
 
 babel-helper-bindify-decorators@^6.24.1:
@@ -649,10 +612,6 @@ babel-plugin-jest-hoist@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz#afedc853bd3f8dc3548ea671fbe69d03cc2c1767"
 
-babel-plugin-react-svg@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-svg/-/babel-plugin-react-svg-2.1.0.tgz#169eeba1a20fa2dee3a71ff38eedd63d08e69487"
-
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
@@ -681,7 +640,7 @@ babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
 
-babel-plugin-syntax-jsx@^6.18.0, babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
+babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
@@ -926,13 +885,6 @@ babel-plugin-transform-object-rest-spread@^6.22.0:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-object-rest-spread@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
-  dependencies:
-    babel-plugin-syntax-object-rest-spread "^6.8.0"
-    babel-runtime "^6.26.0"
-
 babel-plugin-transform-react-display-name@^6.23.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz#67e2bf1f1e9c93ab08db96792e05392bf2cc28d1"
@@ -1065,18 +1017,6 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-register@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
-  dependencies:
-    babel-core "^6.26.0"
-    babel-runtime "^6.26.0"
-    core-js "^2.5.0"
-    home-or-tmp "^2.0.0"
-    lodash "^4.17.4"
-    mkdirp "^0.5.1"
-    source-map-support "^0.4.15"
-
 babel-runtime@^6.18.0, babel-runtime@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
@@ -1091,13 +1031,6 @@ babel-runtime@^6.2.0, babel-runtime@^6.9.2:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
-
 babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0, babel-template@^6.3.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
@@ -1107,16 +1040,6 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0, babel-te
     babel-types "^6.25.0"
     babylon "^6.17.2"
     lodash "^4.2.0"
-
-babel-template@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
-  dependencies:
-    babel-runtime "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    lodash "^4.17.4"
 
 babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
   version "6.25.0"
@@ -1132,20 +1055,6 @@ babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-tr
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    debug "^2.6.8"
-    globals "^9.18.0"
-    invariant "^2.2.2"
-    lodash "^4.17.4"
-
 babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
@@ -1155,15 +1064,6 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babel-types@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
-  dependencies:
-    babel-runtime "^6.26.0"
-    esutils "^2.0.2"
-    lodash "^4.17.4"
-    to-fast-properties "^1.0.3"
-
 babylon@7.0.0-beta.31:
   version "7.0.0-beta.31"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.31.tgz#7ec10f81e0e456fd0f855ad60fa30c2ac454283f"
@@ -1171,10 +1071,6 @@ babylon@7.0.0-beta.31:
 babylon@^6.17.0, babylon@^6.17.2, babylon@^6.17.4:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
-
-babylon@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 bail@^1.0.0:
   version "1.0.2"
@@ -1232,7 +1128,7 @@ bluebird@^3.4.7:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
-bluebird@^3.5.1:
+bluebird@^3.5.0, bluebird@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -1295,7 +1191,7 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-braces@^2.3.0, braces@^2.3.1:
+braces@^2.2.2, braces@^2.3.0, braces@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.1.tgz#7086c913b4e5a08dbe37ac0ee6a2500c4ba691bb"
   dependencies:
@@ -1737,6 +1633,10 @@ clone@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.2.tgz#260b7a99ebb1edfe247538175f783243cb19d149"
 
+clone@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -1906,10 +1806,6 @@ convert-source-map@^1.1.0, convert-source-map@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
-convert-source-map@^1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
-
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
@@ -1953,10 +1849,6 @@ core-js@^1.0.0:
 core-js@^2.4.0, core-js@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
-
-core-js@^2.5.0:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -2200,6 +2092,10 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deepmerge@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.3.2.tgz#1663691629d4dbfe364fa12a2a4f0aa86aa3a050"
+
 default-require-extensions@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
@@ -2400,6 +2296,10 @@ domhandler@^2.3.0:
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
   dependencies:
     domelementtype "1"
+
+domready@1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/domready/-/domready-1.0.8.tgz#91f252e597b65af77e745ae24dd0185d5e26d58c"
 
 domutils@1.1:
   version "1.1.6"
@@ -2921,7 +2821,7 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
-extglob@^2.0.4:
+extglob@^2.0.2, extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
   dependencies:
@@ -3317,7 +3217,7 @@ global-prefix@^1.0.1:
     is-windows "^1.0.1"
     which "^1.2.14"
 
-globals@^9.0.0, globals@^9.17.0, globals@^9.18.0:
+globals@^9.0.0, globals@^9.17.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -3475,7 +3375,7 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-he@1.1.x:
+he@1.1.x, he@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
@@ -3559,7 +3459,7 @@ html-webpack-plugin@^2.30.1:
     pretty-error "^2.0.2"
     toposort "^1.0.0"
 
-htmlparser2@^3.9.1:
+htmlparser2@^3.8.3, htmlparser2@^3.9.1:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
   dependencies:
@@ -3671,6 +3571,10 @@ ignore@^3.3.5:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
+image-size@^0.5.1:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
+
 import-local@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
@@ -3774,7 +3678,7 @@ interpret@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
 
-invariant@^2.2.0, invariant@^2.2.2:
+invariant@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -4101,7 +4005,7 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
-isobject@^2.0.0:
+isobject@^2.0.0, isobject@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
@@ -4584,7 +4488,7 @@ kind-of@^4.0.0:
   dependencies:
     is-buffer "^1.1.5"
 
-kind-of@^5.0.0:
+kind-of@^5.0.0, kind-of@^5.0.2:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
 
@@ -4705,10 +4609,6 @@ lodash.foreach@^4.3.0:
 lodash.isfunction@^3.0.8:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
-
-lodash.isplainobject@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
 
 lodash.isstring@^4.0.1:
   version "4.0.1"
@@ -4902,6 +4802,12 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
+merge-options@0.0.64:
+  version "0.0.64"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-0.0.64.tgz#cbe04f594a6985eaf27f7f8f0b2a3acf6f9d562d"
+  dependencies:
+    is-plain-obj "^1.1.0"
+
 merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
@@ -4909,6 +4815,24 @@ merge@^1.1.3:
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+
+micromatch@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.0.tgz#5102d4eaf20b6997d6008e3acfe1c44a3fa815e2"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.2.2"
+    define-property "^1.0.0"
+    extend-shallow "^2.0.1"
+    extglob "^2.0.2"
+    fragment-cache "^0.2.1"
+    kind-of "^5.0.2"
+    nanomatch "^1.2.1"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 micromatch@^2.1.5, micromatch@^2.3.11:
   version "2.3.11"
@@ -5032,6 +4956,10 @@ mississippi@^2.0.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
+mitt@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-1.1.2.tgz#380e61480d6a615b660f07abb60d51e0a4e4bed6"
+
 mixin-deep@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
@@ -5079,7 +5007,7 @@ nan@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
 
-nanomatch@^1.2.9:
+nanomatch@^1.2.1, nanomatch@^1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.9.tgz#879f7150cb2dab7a471259066c104eee6e0fa7c2"
   dependencies:
@@ -5559,7 +5487,7 @@ path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
 
-path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
+path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
@@ -5830,6 +5758,12 @@ postcss-ordered-values@^2.1.0:
     postcss "^5.0.4"
     postcss-value-parser "^3.0.1"
 
+postcss-prefix-selector@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/postcss-prefix-selector/-/postcss-prefix-selector-1.6.0.tgz#b495949d639c63147145648326853216f3c10900"
+  dependencies:
+    postcss "^5.0.8"
+
 postcss-reduce-idents@^2.2.2:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz#c2c6d20cc958284f6abfbe63f7609bf409059ad3"
@@ -5897,6 +5831,15 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
+postcss@^5.2.17:
+  version "5.2.18"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
+  dependencies:
+    chalk "^1.1.3"
+    js-base64 "^2.1.9"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
+
 postcss@^6.0.1:
   version "6.0.8"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.8.tgz#89067a9ce8b11f8a84cbc5117efc30419a0857b3"
@@ -5904,6 +5847,39 @@ postcss@^6.0.1:
     chalk "^2.0.1"
     source-map "^0.5.6"
     supports-color "^4.2.0"
+
+posthtml-parser@^0.2.0, posthtml-parser@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.2.1.tgz#35d530de386740c2ba24ff2eb2faf39ccdf271dd"
+  dependencies:
+    htmlparser2 "^3.8.3"
+    isobject "^2.1.0"
+
+posthtml-rename-id@^1.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/posthtml-rename-id/-/posthtml-rename-id-1.0.3.tgz#acc7a7af62a58a695e8ab9c2d0b6b462ab3ee17f"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+posthtml-render@^1.0.5, posthtml-render@^1.0.6:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-1.1.0.tgz#854fcaaf3d4b9c8c1dc736fd5d80e52b709d98b7"
+
+posthtml-svg-mode@^1.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/posthtml-svg-mode/-/posthtml-svg-mode-1.0.2.tgz#133efbf543e1bab8c0408f6ac0eac987772820b8"
+  dependencies:
+    merge-options "0.0.64"
+    posthtml "^0.9.2"
+    posthtml-parser "^0.2.1"
+    posthtml-render "^1.0.6"
+
+posthtml@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/posthtml/-/posthtml-0.9.2.tgz#f4c06db9f67b61fd17c4e256e7e3d9515bf726fd"
+  dependencies:
+    posthtml-parser "^0.2.0"
+    posthtml-render "^1.0.5"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -5934,10 +5910,6 @@ pretty-format@^20.0.3:
 private@^0.1.6, private@~0.1.5:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
-
-private@^0.1.7:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -6052,7 +6024,7 @@ qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
-query-string@^4.1.0:
+query-string@^4.1.0, query-string@^4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
   dependencies:
@@ -6258,25 +6230,6 @@ react-styleguidist@^6.2.5:
     webpack-dev-server "^2.9.7"
     webpack-merge "^4.1.1"
 
-react-svg-core@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-svg-core/-/react-svg-core-2.1.0.tgz#3700322af70117c91f83f18febb481128de3cfbb"
-  dependencies:
-    babel-core "^6.26.0"
-    babel-plugin-react-svg "^2.1.0"
-    babel-plugin-syntax-jsx "^6.18.0"
-    babel-plugin-transform-object-rest-spread "^6.26.0"
-    babel-preset-react "^6.24.1"
-    lodash.isplainobject "^4.0.6"
-    svgo "^0.7.2"
-
-react-svg-loader@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-svg-loader/-/react-svg-loader-2.1.0.tgz#ba15019413b9b11e2012e86580aea1eecc93677e"
-  dependencies:
-    loader-utils "^1.1.0"
-    react-svg-core "^2.1.0"
-
 react-test-renderer@^15.5.0:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.1.tgz#026f4a5bb5552661fd2cc4bbcd0d4bc8a35ebf7e"
@@ -6409,10 +6362,6 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
-
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
 regenerator-transform@0.9.11:
   version "0.9.11"
@@ -6950,12 +6899,6 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.4.15:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
-  dependencies:
-    source-map "^0.5.6"
-
 source-map-support@^0.4.2:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.15.tgz#03202df65c06d2bd8c7ec2362a193056fef8d3b1"
@@ -7231,7 +7174,46 @@ supports-color@^5.1.0, supports-color@^5.2.0:
   dependencies:
     has-flag "^3.0.0"
 
-svgo@^0.7.0, svgo@^0.7.2:
+svg-baker-runtime@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/svg-baker-runtime/-/svg-baker-runtime-1.3.3.tgz#077c21baceb45424928883b3343d298b19edd8ef"
+  dependencies:
+    deepmerge "1.3.2"
+    mitt "1.1.2"
+    svg-baker "^1.2.0"
+
+svg-baker@^1.2.0, svg-baker@^1.2.17:
+  version "1.2.17"
+  resolved "https://registry.yarnpkg.com/svg-baker/-/svg-baker-1.2.17.tgz#452ceaa604f784e4b864740e4b6b3faf6458d016"
+  dependencies:
+    bluebird "^3.5.0"
+    clone "^2.1.1"
+    he "^1.1.1"
+    image-size "^0.5.1"
+    loader-utils "^1.1.0"
+    merge-options "0.0.64"
+    micromatch "3.1.0"
+    postcss "^5.2.17"
+    postcss-prefix-selector "^1.6.0"
+    posthtml-rename-id "^1.0"
+    posthtml-svg-mode "^1.0"
+    query-string "^4.3.2"
+    traverse "^0.6.6"
+
+svg-sprite-loader@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/svg-sprite-loader/-/svg-sprite-loader-3.6.2.tgz#3d700a9c4728c12934f400597364e80eaa0f9e6e"
+  dependencies:
+    bluebird "^3.5.0"
+    deepmerge "1.3.2"
+    domready "1.0.8"
+    escape-string-regexp "1.0.5"
+    loader-utils "^1.1.0"
+    svg-baker "^1.2.17"
+    svg-baker-runtime "^1.3.3"
+    url-slug "2.0.0"
+
+svgo@^0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.7.2.tgz#9f5772413952135c6fefbf40afe6a4faa88b4bb5"
   dependencies:
@@ -7359,7 +7341,7 @@ to-ast@^1.0.0:
     ast-types "^0.7.2"
     esprima "^2.1.0"
 
-to-fast-properties@^1.0.1, to-fast-properties@^1.0.3:
+to-fast-properties@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
@@ -7397,6 +7379,10 @@ tough-cookie@^2.3.2, tough-cookie@~2.3.0:
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+
+traverse@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
 
 trim-newlines@^1.0.0:
   version "1.0.0"
@@ -7528,6 +7514,10 @@ unherit@^1.0.4:
     inherits "^2.0.1"
     xtend "^4.0.1"
 
+unidecode@0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/unidecode/-/unidecode-0.1.8.tgz#efbb301538bc45246a9ac8c559d72f015305053e"
+
 unified@^6.0.0:
   version "6.1.5"
   resolved "https://registry.yarnpkg.com/unified/-/unified-6.1.5.tgz#716937872621a63135e62ced2f3ac6a063c6fb87"
@@ -7654,6 +7644,12 @@ url-parse@^1.1.8:
   dependencies:
     querystringify "~1.0.0"
     requires-port "1.0.x"
+
+url-slug@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/url-slug/-/url-slug-2.0.0.tgz#a789d5aed4995c0d95af33377ad1d5c68d4d7027"
+  dependencies:
+    unidecode "0.1.8"
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
## What
Makes Radio, RadioGroup and Checkbox compatible with IE >= 10 and Safari.

## Why
SVG's were not showing up correctly on those browsers.

**NOTE**
IE 10 and 11 have a bug that prevents them from rendering the fill color defined in inline SVG's under certain circumstances:
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/10898469/

This is affecting the components modified in this PR. At this point I consider that it may not be worth spending more time looking for a workaround to make the SVG render in color on those two browsers:

![screen shot 2018-02-21 at 6 07 44 pm](https://user-images.githubusercontent.com/9634729/36516827-95c37bbe-1734-11e8-8eeb-cc2a355f17bd.png)
![screen shot 2018-02-21 at 5 43 58 pm](https://user-images.githubusercontent.com/9634729/36516828-95decc84-1734-11e8-8199-ee9f70c71449.png)

On all other browsers the components appear to display correctly:

**SAFARI**
![screen shot 2018-02-21 at 6 26 12 pm](https://user-images.githubusercontent.com/9634729/36516851-b77d29e4-1734-11e8-8de2-0b7a4f20c712.png)

**EDGE**
![screen shot 2018-02-21 at 6 09 26 pm](https://user-images.githubusercontent.com/9634729/36516861-bd699e14-1734-11e8-8790-c53e817182e2.png)
