### PR TITLE
Export themePropTypes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,23 +33,30 @@ import withTheme from './styles/themer/withTheme'
 import Slide from './components/Transitions/Slide'
 import Grow from './components/Transitions/Grow'
 import Fade from './components/Transitions/Fade'
+import { themePropTypes } from './styles/themer/utils'
 
 export {
-  // base
+  // styles
   colors,
   zIndex,
-  // styles
+  
+  // style overriding ()
   GlobalTheme,
   Normalize,
   SetStyles,
+
+  // theming
   themer,
   withTheme,
+  themePropTypes,
+
   // grid system
   responsive,
   spacing,
   Grid,
   Column,
   Row,
+  
   //forms
   Form,
   FormComponent,

--- a/src/styles/themer/docs/withTheme.md
+++ b/src/styles/themer/docs/withTheme.md
@@ -31,7 +31,7 @@ const MyComponent = props => {
   )
 }
 
-ButMyComponentton.propTypes = {
+MyComponent.propTypes = {
   snacksTheme: themePropTypes
 }
 

--- a/src/styles/themer/docs/withTheme.md
+++ b/src/styles/themer/docs/withTheme.md
@@ -21,7 +21,7 @@ Class with decorator style
 
 Functional style
 ```js static
-import { withTheme } from 'ic-snacks'
+import { withTheme, themePropTypes } from 'ic-snacks'
 
 const MyComponent = props => {
   return (
@@ -31,5 +31,11 @@ const MyComponent = props => {
   )
 }
 
+ButMyComponentton.propTypes = {
+  snacksTheme: themePropTypes
+}
+
 export default withTheme(MyComponent)
 ```
+
+`themePropTypes` is available to make propTypes definitions easier, as well.


### PR DESCRIPTION
Snacks users who want to theme their own components using the `withTheme` HOC currently must write out their own propTypes for the `snacksTheme`. This is repetitive, but also could be fragile. If the theme config changes, users shouldn't have to re-write all their propTypes.

Now they can do
```js
import { withTheme, themePropTypes } from 'ic-snacks'

const MyComponent = props => {
  return (
    <p style={{ color: props.snacksTheme.color.action }}>
      Hi!
    </p>
  )
}

MyComponent.propTypes = {
  snacksTheme: themePropTypes
}
```