### PR TITLE
Fix issue withTheme and refs

### DIFF
--- a/src/styles/themer/withTheme.js
+++ b/src/styles/themer/withTheme.js
@@ -27,6 +27,7 @@ function withTheme(InnerComponent) {
     render() {
       return (
         <InnerComponent
+          ref={node => this.wrapped = node}
           {...this.props}
           snacksTheme={themer.themeConfig}
         />


### PR DESCRIPTION
An issue came up in the main Instacart app with the most recent snacks
release (0.0.73). In a few cases we referenced FormComponent directly
on a snacks component instance, e.g. `const input = textInput.FormComponent.input`.

Because we added withTheme to each snacks form component, FormComponent
was no longer available because the ref was referencing withThemes
wrapped component instance.

This commit adds a ref to withTheme, so we still have at least once way
to access an underlying dom node for things like inputs. Long term we
should add something directly to our component APIs so users can not
have to rely on internals like FormComponent.