### PR TITLE
Responsive helpers

### DIFF
--- a/src/styles/__tests__/responsive.spec.js
+++ b/src/styles/__tests__/responsive.spec.js
@@ -1,0 +1,51 @@
+import responsive, { sizes } from '../responsive'
+const { __v2__ } = responsive
+
+const { up, down } = __v2__
+
+describe('up', () => {
+  it('ignores xs as an argument because it has no lower bound')
+
+  it('returns a media query that matches screens larger than the given screen size', () => {
+    const ss = Object.keys(sizes)
+
+    // TODO: xs isn't valid for up, it has no lower bound
+    ss.filter(size => size !== 'xs').forEach(size => {
+      expect(up(size)).toEqual(`@media (min-width: ${sizes[size].min}px)`)
+    })
+
+    // TODO: should maybe do one sanity check in case i messed up attaching the constsnts in sizes?
+    // should i import constants or hardcode
+    expect(up('sm')).toEqual(`@media (min-width: ${768}px)`)
+  })
+})
+
+describe('down', () => {
+  it('ignores xl as an argument because it has no upper bound')
+
+  it('returns a media query that matches screens smaller than the given screen size', () => {
+    const ss = Object.keys(sizes)
+
+    // TODO: xl isn't valid for down, xl has no upper bound
+    ss.filter(size => size !== 'xl').forEach(size => {
+      expect(down(size)).toEqual(`@media (max-width: ${sizes[size].max}px)`)
+    })
+
+    // TODO: same as above
+  })
+})
+
+describe('only', () => {
+  it('works for xs')
+  it('works for xl')
+
+  it('works for every other size that has both a lower/upper bound', () => {
+    expect(1).toEqual(1)
+  })
+})
+
+describe('between', () => {
+  it("returns a media query that matches screens between each given size's min value", () => {
+    expect(1).toEqual(1)
+  })
+})

--- a/src/styles/__tests__/responsive.spec.js
+++ b/src/styles/__tests__/responsive.spec.js
@@ -1,49 +1,70 @@
-import responsive, { sizes } from '../responsive'
+import responsive, { breakpoints } from '../responsive'
 
 const { up, down, only, between } = responsive
 
 describe('up', () => {
-  it('ignores xs as an argument because it has no lower bound')
+  it('returns a media query that matches the given screen size or larger', () => {
+    const breakpointNames = Object.keys(breakpoints)
 
-  it('returns a media query that matches screens larger than the given screen size', () => {
-    const ss = Object.keys(sizes)
-
-    // TODO: xs isn't valid for up, it has no lower bound
-    ss.filter(size => size !== 'xs').forEach(size => {
-      expect(up(size)).toEqual(`@media (min-width: ${sizes[size].min}px)`)
+    breakpointNames.forEach(size => {
+      expect(up(size)).toEqual(`@media (min-width: ${breakpoints[size].min}px)`)
     })
-
-    // TODO: should maybe do one sanity check in case i messed up attaching the constsnts in sizes?
-    expect(up('sm')).toEqual(`@media (min-width: ${768}px)`)
   })
 })
 
 describe('down', () => {
-  it('ignores xl as an argument because it has no upper bound')
+  it('ignores xl as an argument because it has no upper bound', () => {
+    expect(() => down('xl')).toThrow()
+  })
 
-  it('returns a media query that matches screens smaller than the given screen size', () => {
-    const ss = Object.keys(sizes)
+  it('returns a media query that matches the given screen size or smaller', () => {
+    const breakpointNames = Object.keys(breakpoints).filter(b => b !== 'xl')
 
-    // TODO: xl isn't valid for down, xl has no upper bound
-    ss.filter(size => size !== 'xl').forEach(size => {
-      expect(down(size)).toEqual(`@media (max-width: ${sizes[size].max}px)`)
+    breakpointNames.forEach(size => {
+      expect(down(size)).toEqual(`@media (max-width: ${breakpoints[size].max}px)`)
     })
-
-    // TODO: same as above
   })
 })
 
 describe('only', () => {
-  it('works for xs')
-  it('works for xl')
+  it('works for the smallest size', () => {
+    expect(only('xs')).toEqual(`@media (max-width: ${breakpoints.xs.max}px)`)
+  })
 
-  it('works for every other size that has both a lower/upper bound', () => {
-    expect(only('xs')).toEqual('hi')
+  it('works for the largest size', () => {
+    expect(only('xl')).toEqual(`@media (min-width: ${breakpoints.xl.min}px)`)
+  })
+
+  it('works for every size that has both a lower/upper bound', () => {
+    const breakpointNames = ['sm', 'md', 'mdLg', 'lg']
+
+    breakpointNames.forEach(size => {
+      expect(only(size)).toEqual(`@media (min-width: ${breakpoints[size].min}px) and (max-width: ${breakpoints[size].max}px)`)
+    })
   })
 })
 
 describe('between', () => {
-  it("returns a media query that matches screens between each given size's min value", () => {
-    expect(between('sm', 'lg')).toEqual('hi')
+  it('returns a media query that matches screens between each given size\'s minimum value', () => {
+    const testCases = [
+      ['xs', 'md'],
+      ['sm', 'md'],
+      ['sm', 'xl'],
+      ['md', 'xl']
+    ]
+
+    testCases.forEach(t => {
+      const [ lower, upper ] = t
+      const expected = `@media (min-width: ${breakpoints[lower].min}px) and (max-width: ${breakpoints[upper].min}px)`
+
+      expect(between(lower, upper)).toEqual(expected)
+    })
   })
+})
+
+it('throws an error when invalid screen sizes are given', () => {
+  expect(() => up('not')).toThrow()
+  expect(() => down('a')).toThrow()
+  expect(() => only('valid')).toThrow()
+  expect(() => between('screen', 'size')).toThrow()
 })

--- a/src/styles/__tests__/responsive.spec.js
+++ b/src/styles/__tests__/responsive.spec.js
@@ -1,7 +1,6 @@
 import responsive, { sizes } from '../responsive'
-const { __v2__ } = responsive
 
-const { up, down } = __v2__
+const { up, down, only, between } = responsive
 
 describe('up', () => {
   it('ignores xs as an argument because it has no lower bound')
@@ -15,7 +14,6 @@ describe('up', () => {
     })
 
     // TODO: should maybe do one sanity check in case i messed up attaching the constsnts in sizes?
-    // should i import constants or hardcode
     expect(up('sm')).toEqual(`@media (min-width: ${768}px)`)
   })
 })
@@ -40,12 +38,12 @@ describe('only', () => {
   it('works for xl')
 
   it('works for every other size that has both a lower/upper bound', () => {
-    expect(1).toEqual(1)
+    expect(only('xs')).toEqual('hi')
   })
 })
 
 describe('between', () => {
   it("returns a media query that matches screens between each given size's min value", () => {
-    expect(1).toEqual(1)
+    expect(between('sm', 'lg')).toEqual('hi')
   })
 })

--- a/src/styles/docs/responsive.md
+++ b/src/styles/docs/responsive.md
@@ -1,0 +1,34 @@
+For visual consistency we've created a fixed set of screen sizes
+based on the Snacks grid system.
+
+| Screen Size | Px value         |
+|-------------|------------------|
+| xs          | 0 - 768px        |
+| sm          | 768px - 831px    |
+| md          | 832px - 1039px   |
+| mdLg        | 1040px - 1247px  |
+| lg          | 1248px - 1455px  |
+| xl          | > 1456px         |
+
+There are four helpers available for generating media queries:
+
+```js static
+// Target a given screen size and larger
+up('sm') //=> '@media (min-width: 768px)'
+up('lg') //=> '@media (min-width: 1248px)'
+
+// Target a given screen size and smaller
+down('sm') //=> '@media (max-width: 831px)'
+down('lg') //=> '@media (min-width: 1248px)'
+
+// Target a single screen size
+only('xs') //=> '@media (max-width: 768px)'
+only('md') //=> '@media (min-width: 832px) and (max-width: 1039px)'
+only('lg') //=> '@media (min-width: 1248px) and (max-width: 1455px)'
+
+// Target a given screen size up to but
+// not including a second screen size
+between('sm', 'md') //=> '@media (min-width: 0px) and (max-width: 832px)'
+between('sm', 'xl') //=> '@media (min-width: 768px) and (max-width: 1456px)'
+```
+

--- a/src/styles/responsive.js
+++ b/src/styles/responsive.js
@@ -1,30 +1,85 @@
-const COLUMN_WIDTH =    104               // 1/2 Item Card width
+const COLUMN_WIDTH = 104 // 1/2 Item Card width
 
-const SCREEN_SM_MIN =   768               // 6 columns rounded
-const SCREEN_MD_MIN =   COLUMN_WIDTH * 8  // 832
+const SCREEN_SM_MIN = 768 // 6 columns rounded
+const SCREEN_MD_MIN = COLUMN_WIDTH * 8 // 832
 const SCREEN_MDLG_MIN = COLUMN_WIDTH * 10 // 1040
-const SCREEN_LG_MIN =   COLUMN_WIDTH * 12 // 1248
-const SCREEN_XL_MIN =   COLUMN_WIDTH * 14 // 1456 (max width)
+const SCREEN_LG_MIN = COLUMN_WIDTH * 12 // 1248
+const SCREEN_XL_MIN = COLUMN_WIDTH * 14 // 1456 (max width)
 
-const SCREEN_XS_MAX = SCREEN_SM_MIN - 1   // 767
-const SCREEN_SM_MAX = SCREEN_MD_MIN - 1   // 831
+const SCREEN_XS_MAX = SCREEN_SM_MIN - 1 // 767
+const SCREEN_SM_MAX = SCREEN_MD_MIN - 1 // 831
 const SCREEN_MD_MAX = SCREEN_MDLG_MIN - 1 // 1039
 const SCREEN_MDLG_MAX = SCREEN_LG_MIN - 1 // 1247
-const SCREEN_LG_MAX = SCREEN_XL_MIN - 1   // 1455
+const SCREEN_LG_MAX = SCREEN_XL_MIN - 1 // 1455
+
+export const sizes = {
+  xs: {
+    max: SCREEN_XS_MAX
+  },
+  sm: {
+    min: SCREEN_SM_MIN,
+    max: SCREEN_SM_MAX
+  },
+  md: {
+    min: SCREEN_MD_MIN,
+    max: SCREEN_MD_MAX
+  },
+  mdLg: {
+    min: SCREEN_MDLG_MIN,
+    max: SCREEN_MDLG_MAX
+  },
+  lg: {
+    min: SCREEN_LG_MIN,
+    max: SCREEN_LG_MAX
+  },
+  xl: {
+    min: SCREEN_XL_MIN
+    // TODO: no max, hmmm
+  }
+}
+
+const v2Api = { up, down, only, between }
+
+// sizes: xs, sm, md, mdLg, lg, xl
+function up(size) {
+  if (size === 'xs') {
+    // TODO: throw here? is there a way to have nothing be considered a non-media query for radium?
+    return ''
+  }
+
+  if (!sizes[size].min) console.log('FUCK', size)
+  return `@media (min-width: ${sizes[size].min}px)`
+}
+
+function down(size) {
+  return `@media (max-width: ${sizes[size].max}px)`
+}
+
+function only(size) {
+  const { min, max } = sizes[size]
+  return `@media (min-width: ${min}px) and (max-width: ${max}px)`
+}
+
+function between(lower, upper) {
+  const min = sizes[lower].min
+  const max = sizes[upper].min
+  return `@media (min-width: ${min}px) and (max-width: ${max}px)`
+}
 
 export default {
-  xs:   `@media (max-width: ${SCREEN_XS_MAX}px)`,
-  sm:   `@media (min-width: ${SCREEN_SM_MIN}px) and (max-width: ${SCREEN_SM_MAX}px)`,
-  md:   `@media (min-width: ${SCREEN_MD_MIN}px) and (max-width: ${SCREEN_MD_MAX}px)`,
+  xs: `@media (max-width: ${SCREEN_XS_MAX}px)`,
+  sm: `@media (min-width: ${SCREEN_SM_MIN}px) and (max-width: ${SCREEN_SM_MAX}px)`,
+  md: `@media (min-width: ${SCREEN_MD_MIN}px) and (max-width: ${SCREEN_MD_MAX}px)`,
   mdLg: `@media (min-width: ${SCREEN_MDLG_MIN}px) and (max-width: ${SCREEN_MDLG_MAX}px)`,
-  lg:   `@media (min-width: ${SCREEN_LG_MIN}px) and (max-width: ${SCREEN_LG_MAX}px)`,
-  xl:   `@media (min-width: ${SCREEN_XL_MIN}px)`,
+  lg: `@media (min-width: ${SCREEN_LG_MIN}px) and (max-width: ${SCREEN_LG_MAX}px)`,
+  xl: `@media (min-width: ${SCREEN_XL_MIN}px)`,
   columnWidth: COLUMN_WIDTH,
   screenWidths: {
     sm: COLUMN_WIDTH * 6,
     md: SCREEN_MD_MIN,
     mdLg: SCREEN_MDLG_MIN,
     lg: SCREEN_LG_MIN,
-    xl: SCREEN_XL_MIN,
-  }
+    xl: SCREEN_XL_MIN
+  },
+  __v2__: v2Api
 }

--- a/src/styles/responsive.js
+++ b/src/styles/responsive.js
@@ -12,10 +12,9 @@ const SCREEN_MD_MAX = SCREEN_MDLG_MIN - 1 // 1039
 const SCREEN_MDLG_MAX = SCREEN_LG_MIN - 1 // 1247
 const SCREEN_LG_MAX = SCREEN_XL_MIN - 1   // 1455
 
-// TODO: exporting just for test (so far at least), smell?
-export const sizes = {
+export const breakpoints = {
   xs: {
-    // TODO: no min, hmmm
+    min: 0,
     max: SCREEN_XS_MAX
   },
   sm: {
@@ -36,18 +35,21 @@ export const sizes = {
   },
   xl: {
     min: SCREEN_XL_MIN
-    // TODO: no max, hmmm
   }
 }
 
-// all sizes: xs, sm, md, mdLg, lg, xl
-// TODO: better error messages
-const up = (size) => {
-  if (size === 'xs') {
-    throw new Error('size "xs" not supported')
-  }
+const assertValidSizes = (...sizes) => {
+  sizes.forEach(size => {
+    if (breakpoints[size] === undefined) {
+      throw new Error(`Screen size(s) ${sizes.join(', ')} not supported. Must be one of ${Object.keys(breakpoints).join(', ')}`) // eslint-disable-line
+    }
+  })
+}
 
-  return `@media (min-width: ${sizes[size].min}px)`
+const up = (size) => {
+  assertValidSizes(size)
+
+  return `@media (min-width: ${breakpoints[size].min}px)`
 }
 
 const down = (size) => {
@@ -55,11 +57,15 @@ const down = (size) => {
     throw new Error('size "xl" not supported')
   }
 
-  return `@media (max-width: ${sizes[size].max}px)`
+  assertValidSizes(size)
+
+  return `@media (max-width: ${breakpoints[size].max}px)`
 }
 
 const only = (size) => {
-  const { min, max } = sizes[size]
+  assertValidSizes(size)
+
+  const { min, max } = breakpoints[size]
 
   if (!min) {
     return `@media (max-width: ${max}px)`
@@ -72,10 +78,13 @@ const only = (size) => {
   return `@media (min-width: ${min}px) and (max-width: ${max}px)`
 }
 
-const between = (lower, upper) => {
-  const min = sizes[lower].min
-  const max = sizes[upper].max
-  return `@media (min-width: ${min}px) and (max-width: ${max}px)`
+const between = (lowerSize, upperSize) => {
+  assertValidSizes(lowerSize, upperSize)
+
+  const lower = breakpoints[lowerSize].min
+  const upper = breakpoints[upperSize].min
+
+  return `@media (min-width: ${lower}px) and (max-width: ${upper}px)`
 }
 
 export default {
@@ -94,7 +103,9 @@ export default {
     xl: SCREEN_XL_MIN
   },
 
-  // Helpers
+  // New breakpoint helpers. These do everything the existing
+  // breakpoints do and are more flexible, so they should eventually
+  // replace the individual size exports.
   up,
   down,
   only,

--- a/src/styles/responsive.js
+++ b/src/styles/responsive.js
@@ -12,8 +12,10 @@ const SCREEN_MD_MAX = SCREEN_MDLG_MIN - 1 // 1039
 const SCREEN_MDLG_MAX = SCREEN_LG_MIN - 1 // 1247
 const SCREEN_LG_MAX = SCREEN_XL_MIN - 1 // 1455
 
+// TODO: exporting just for test (so far at least), smell?
 export const sizes = {
   xs: {
+    // TODO: no min, hmmm
     max: SCREEN_XS_MAX
   },
   sm: {
@@ -38,31 +40,41 @@ export const sizes = {
   }
 }
 
-const v2Api = { up, down, only, between }
-
-// sizes: xs, sm, md, mdLg, lg, xl
-function up(size) {
+// all sizes: xs, sm, md, mdLg, lg, xl
+// TODO: better error messages
+const up = (size) => {
   if (size === 'xs') {
-    // TODO: throw here? is there a way to have nothing be considered a non-media query for radium?
-    return ''
+    throw new Error('size "xs" not supported')
   }
 
-  if (!sizes[size].min) console.log('FUCK', size)
   return `@media (min-width: ${sizes[size].min}px)`
 }
 
-function down(size) {
+const down = (size) => {
+  if (size === 'xl') {
+    throw new Error('size "xl" not supported')
+  }
+
   return `@media (max-width: ${sizes[size].max}px)`
 }
 
-function only(size) {
+const only = (size) => {
   const { min, max } = sizes[size]
+
+  if (!min) {
+    return `@media (max-width: ${max}px)`
+  }
+
+  if (!max) {
+    return `@media (min-width: ${min}px)`
+  }
+
   return `@media (min-width: ${min}px) and (max-width: ${max}px)`
 }
 
-function between(lower, upper) {
+const between = (lower, upper) => {
   const min = sizes[lower].min
-  const max = sizes[upper].min
+  const max = sizes[upper].max
   return `@media (min-width: ${min}px) and (max-width: ${max}px)`
 }
 
@@ -81,5 +93,10 @@ export default {
     lg: SCREEN_LG_MIN,
     xl: SCREEN_XL_MIN
   },
-  __v2__: v2Api
+
+  // Helpers
+  up,
+  down,
+  only,
+  between
 }

--- a/src/styles/responsive.js
+++ b/src/styles/responsive.js
@@ -1,16 +1,16 @@
-const COLUMN_WIDTH = 104 // 1/2 Item Card width
+const COLUMN_WIDTH = 104                  // 1/2 Item Card width
 
-const SCREEN_SM_MIN = 768 // 6 columns rounded
-const SCREEN_MD_MIN = COLUMN_WIDTH * 8 // 832
+const SCREEN_SM_MIN = 768                 // 6 columns rounded
+const SCREEN_MD_MIN = COLUMN_WIDTH * 8    // 832
 const SCREEN_MDLG_MIN = COLUMN_WIDTH * 10 // 1040
-const SCREEN_LG_MIN = COLUMN_WIDTH * 12 // 1248
-const SCREEN_XL_MIN = COLUMN_WIDTH * 14 // 1456 (max width)
+const SCREEN_LG_MIN = COLUMN_WIDTH * 12   // 1248
+const SCREEN_XL_MIN = COLUMN_WIDTH * 14   // 1456 (max width)
 
-const SCREEN_XS_MAX = SCREEN_SM_MIN - 1 // 767
-const SCREEN_SM_MAX = SCREEN_MD_MIN - 1 // 831
+const SCREEN_XS_MAX = SCREEN_SM_MIN - 1   // 767
+const SCREEN_SM_MAX = SCREEN_MD_MIN - 1   // 831
 const SCREEN_MD_MAX = SCREEN_MDLG_MIN - 1 // 1039
 const SCREEN_MDLG_MAX = SCREEN_LG_MIN - 1 // 1247
-const SCREEN_LG_MAX = SCREEN_XL_MIN - 1 // 1455
+const SCREEN_LG_MAX = SCREEN_XL_MIN - 1   // 1455
 
 // TODO: exporting just for test (so far at least), smell?
 export const sizes = {

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -20,12 +20,21 @@ module.exports = {
       content: 'docs/installation.md'
     },
     {
-      name: 'Colors',
-      content: 'docs/colors.md'
-    },
-    {
-      name: 'Spacing',
-      content: 'docs/spacing.md'
+      name: 'Utilities',
+      sections: [
+        {
+          name: 'Colors',
+          content: 'docs/colors.md'
+        },
+        {
+          name: 'Spacing',
+          content: 'docs/spacing.md'
+        },
+        {
+          name: 'Responsive',
+          content: 'src/styles/docs/responsive.md'
+        },
+      ]
     },
     {
       name: 'Icons',


### PR DESCRIPTION
### What

This commit adds a few responsive helpers (inspired by bootstrap 4 https://getbootstrap.com/docs/4.0/layout/overview/#responsive-breakpoints)

* `up`
* `down`
* `between`
* `only`

### Why

Currently the `responsive` utility only allows users to target a single screen size at a time. So if a user wants to apply styles to xs, sm, and md screens, they'd have to write something like:

```
const styles = {
  [responsive.xs]: { color: 'blanchedalmond' },
  [responsive.sm]: { color: 'blanchedalmond' },
  [responsive.md]: { color: 'blanchedalmond' }
}
```

These new utils provide a much more flexible API, and now the same effect can be achieved with:

```
const styles = {
  [responsive.down('md')]: { color: 'blanchedalmond' }
}
```