### PR TITLE
Flat disabled style

### DIFF
--- a/src/components/Buttons/Button.js
+++ b/src/components/Buttons/Button.js
@@ -72,6 +72,12 @@ const getSnacksStyles = props => {
   const { action, actionHover, primaryBackground } = props.snacksTheme.colors
   const actionActive = darken(actionHover, 3)
 
+  const disabled = {
+    backgroundColor: colors.GRAY_74,
+    color: colors.WHITE,
+    cursor: 'not-allowed'
+  }
+
   const activeAndFocus = {
     primary: {
       base: {
@@ -126,7 +132,9 @@ const getSnacksStyles = props => {
         },
         ':active': activeAndFocus.primary.inverted,
         ':focus': activeAndFocus.primary.inverted
-      }
+      },
+
+      disabled
     },
 
     secondary: {
@@ -154,7 +162,9 @@ const getSnacksStyles = props => {
         },
         ':active': activeAndFocus.secondary.inverted,
         ':focus': activeAndFocus.secondary.inverted
-      }
+      },
+
+      disabled
     },
 
     flat: {
@@ -167,6 +177,12 @@ const getSnacksStyles = props => {
         },
         ':active': activeAndFocus.flat,
         ':focus': activeAndFocus.flat
+      },
+
+      disabled: {
+        backgroundColor: 'transparent',
+        color: colors.GRAY_74,
+        cursor: 'not-allowed'
       }
     },
 
@@ -182,22 +198,14 @@ const getSnacksStyles = props => {
         },
         ':active': activeAndFocus.coupon,
         ':focus': activeAndFocus.coupon
-      }
-    },
+      },
 
-    disabled: {
-      base: {
-        backgroundColor: colors.GRAY_74,
-        color: colors.WHITE,
-        cursor: 'not-allowed'
-      }
+      disabled
     }
   }
 }
 
 const Button = props => {
-  // Disabled styles override all other snacks-specific button styles
-  const snacksStyle = props.disabled ? 'disabled' : props.snacksStyle
   const snacksStyles = getSnacksStyles(props)
 
   const ElementType = props.href ? 'a' : 'button'
@@ -209,8 +217,8 @@ const Button = props => {
     style: [
       baseStyles,
       sizeStyles[props.size],
-      snacksStyles[snacksStyle].base,
-      props.inverted && snacksStyles[snacksStyle].inverted,
+      snacksStyles[props.snacksStyle][props.disabled ? 'disabled' : 'base'],
+      props.inverted && snacksStyles[props.snacksStyle].inverted,
       ElementType === 'a' && linkStyles,
       props.style
     ],

--- a/src/components/Buttons/docs/Button.md
+++ b/src/components/Buttons/docs/Button.md
@@ -97,9 +97,15 @@ accessibility concerns (links should navigate, buttons should cause actions).
       Flat Button
     </Button>
   </div>
-  <div>
+  <div style={{marginRight: '24px'}}>
     <div style={{marginBottom: '8px'}}>Large</div>
     <Button snacksStyle="flat" size="large">
+      Flat Button
+    </Button>
+  </div>
+  <div>
+    <div style={{marginBottom: '8px'}}>Disabled</div>
+    <Button snacksStyle="flat" size="standard" disabled>
       Flat Button
     </Button>
   </div>


### PR DESCRIPTION
## What
A better `disabled` styling for the `flat` button style. The `flat` button looks like a link most of the time, but switches to a gray button when disabled. This PR makes the disabled state look like a link.

### Old
<img width="148" alt="image" src="https://user-images.githubusercontent.com/1196158/41561677-69f87530-72ff-11e8-80b2-645a2b018636.png">

### New
<img width="136" alt="image" src="https://user-images.githubusercontent.com/1196158/41561686-6f11e9b6-72ff-11e8-8418-f114fbb52908.png">
