### PR TITLE
[MenuItem] Fix race condition between focus call + unmounting

### DIFF
--- a/src/components/Menus/MenuItem.js
+++ b/src/components/Menus/MenuItem.js
@@ -100,7 +100,9 @@ class MenuItem extends React.Component {
   componentDidUpdate(prevProps) {
     if (!prevProps.focus && this.props.focus) {
       setTimeout(() => {
-        this.menuItem.focus()
+        // Checking the ref exists in case this component
+        // unmounts before the callback runs.
+        this.menuItem && this.menuItem.focus()
       }, 0)
     }
   }

--- a/src/components/Menus/MenuItem.js
+++ b/src/components/Menus/MenuItem.js
@@ -97,10 +97,9 @@ class MenuItem extends React.Component {
     preventDefault: true
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { focus } = this.props
-    if (!focus && nextProps.focus) {
-      setTimeout( () => {
+  componentDidUpdate(prevProps) {
+    if (!prevProps.focus && this.props.focus) {
+      setTimeout(() => {
         this.menuItem.focus()
       }, 0)
     }


### PR DESCRIPTION
We noticed a bunch of errors from app code where `focus()` was being called on a null `menuItem` ref.

I had trouble reproducing it under normal conditions, but was able to repro consistently by delaying the `menuItem.focus()` call in `MenuItem` until after a dropdown had unmounted.

#### To repro

I'm still trying to verify the exact behavior but here's my working theory for how this happens:

1. Dropdown is mounted
2. `MenuItem` CWRP runs, puts `this.menuItem.focus()` on the callback queue (via setTimeout 0)
3. Component unmounts
4. Callback fires, but the `ref` has been cleaned up and we call .focus() on a null object

#### componentDidUpdate vs. componentWillReceiveProps

I want to say `componentDidUpdate` is more reliable for accessing refs because it means the component completed a successful update, but I wouldn't say no to a sanity check here :). As a type this I'm realizing `componentWillReceiveProps` => `componentDidUpdate` might not be a 100% fix since we still run the risk of the callback queue being backed up, giving more time for the dropdown to unmount and hit an issue like this.

#### Questions/TODO

We may need something else, like figuring out something other than `setTimeout(() => {}, 0)`. Adding a guard like `this.menuItem && this.menuItem.focus()` could also work (in other cases I'd probably try and avoid this but here it seems like we have a decent understanding of the issue).

Feedback welcome :).