### PR TITLE
Fix ref on stateless function component warning

### DIFF
--- a/src/styles/themer/__tests__/withTheme.spec.js
+++ b/src/styles/themer/__tests__/withTheme.spec.js
@@ -3,17 +3,21 @@ import renderer from 'react-test-renderer'
 import withTheme from '../withTheme'
 import { themePropTypes } from '../utils'
 
-const TestComponent = withTheme(props => {
-  return (
-    <div 
-      style={{
-        backgroundColor: props.snacksTheme.colors.primaryBackground
-      }}
-    >
-      Hello
-    </div>
-  )
-})
+const TestComponent = withTheme(
+  class extends React.Component { // eslint-disable-line react/prefer-stateless-function
+    render() {
+      return (
+        <div
+          style={{
+            backgroundColor: this.props.snacksTheme.colors.primaryBackground
+          }}
+        >
+          Hello
+        </div>
+      )
+    }
+  }
+)
 
 TestComponent.propTypes = { snacksTheme: themePropTypes }
 


### PR DESCRIPTION
The `withTheme` HOC spec was passing a stateless function component,
which was raising this warning:

"Warning: Stateless function components cannot be given refs.
 Attempts to access this ref will fail"

`withTheme` always needs to be passed a class-based component. It's
actually something I hadn't thought about, but we're fine in all live
components as they're either already a class, or wrapped with `Radium`.