### PR TITLE
Remove tinycolor and add a shadeColor utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "react-text-mask": "^5.3.0",
     "semver": "^5.5.0",
     "svgr": "^1.9.2",
-    "tinycolor2": "^1.4.1",
     "underscore": "^1.8.3",
     "validator": "^9.1.1"
   },

--- a/src/components/Buttons/Button.js
+++ b/src/components/Buttons/Button.js
@@ -5,7 +5,7 @@ import Icon from '../Icon/Icon'
 import withTheme from '../../styles/themer/withTheme'
 import { themePropTypes } from '../../styles/themer/utils'
 import { spacing, colors } from '../../styles'
-import { darken } from '../../utils'
+import { shadeColor } from '../../utils'
 
 const noop = () => {} // eslint-disable-line no-empty-function
 
@@ -70,7 +70,7 @@ const linkStyles = {
 
 const getSnacksStyles = props => {
   const { action, actionHover, primaryBackground } = props.snacksTheme.colors
-  const actionActive = darken(actionHover, 3)
+  const actionActive = shadeColor(actionHover, -0.2)
 
   const disabled = {
     backgroundColor: colors.GRAY_74,

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -1,6 +1,25 @@
-import tinycolor from 'tinycolor2'
 import _ from 'underscore'
 
-export const darken = _.memoize((baseColor, amount) => {
-  return tinycolor(baseColor).darken(amount).toHexString()
-})
+// See https://stackoverflow.com/questions/5560248/programmatically-lighten-or-darken-a-hex-color-or-rgb-and-blend-colors
+function _shadeColor(color, percent) {
+  const f = parseInt(color.slice(1), 16),
+    t = percent < 0 ? 0 : 255,
+    p = percent < 0 ? percent * -1 : percent,
+    R = f >> 16,
+    G = (f >> 8) & 0x00ff,
+    B = f & 0x0000ff
+
+  return (
+    '#' + // eslint-disable-line prefer-template
+    (
+      0x1000000 +
+      (Math.round((t - R) * p) + R) * 0x10000 +
+      (Math.round((t - G) * p) + G) * 0x100 +
+      (Math.round((t - B) * p) + B)
+    )
+      .toString(16)
+      .slice(1)
+  )
+}
+
+export const shadeColor = _.memoize(_shadeColor)

--- a/yarn.lock
+++ b/yarn.lock
@@ -8856,10 +8856,6 @@ timers-browserify@^2.0.2:
   dependencies:
     setimmediate "^1.0.4"
 
-tinycolor2@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
-
 tmp@^0.0.31:
   version "0.0.31"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"


### PR DESCRIPTION
Themes define colors for hover states, but not focus states. To get focus colors we take the hover color and darken it by 20%. Previously we used `tinycolor` to do that, but it has a bunch of functionality we don't need. This replaces it with a single `shadeColor` function which gets us the same end result and shaves ~16k (not huge, but still nice) from the final bundle (uncompressed).