### PR TITLE
Stateless components cannot have refs in React 16

### DIFF
--- a/src/styles/themer/withTheme.js
+++ b/src/styles/themer/withTheme.js
@@ -5,7 +5,7 @@ import themer from './index'
 import { themePropTypes } from './utils'
 
 const isStateless = (Component) => {
-  return Component.prototype && !Component.prototype.render
+  return !Component.prototype.render
 }
 
 function withTheme(InnerComponent) {

--- a/src/styles/themer/withTheme.js
+++ b/src/styles/themer/withTheme.js
@@ -4,6 +4,10 @@ import React, { Component } from 'react'
 import themer from './index'
 import { themePropTypes } from './utils'
 
+const isStateless = (Component) => {
+  return Component.prototype && !Component.prototype.render
+}
+
 function withTheme(InnerComponent) {
   class Wrapped extends Component {
     static displayName = `withTheme(${InnerComponent.name || InnerComponent.displayName || 'Component'})`
@@ -25,9 +29,11 @@ function withTheme(InnerComponent) {
     }
 
     render() {
+      const getRef = (node) => this.wrapped = node
+
       return (
         <InnerComponent
-          ref={node => this.wrapped = node}
+          ref={isStateless(InnerComponent) ? undefined : getRef}
           {...this.props}
           snacksTheme={themer.themeConfig}
         />


### PR DESCRIPTION
Fixes this warning when used with react 16:
![image](https://user-images.githubusercontent.com/2035141/42392873-30c0bd46-8109-11e8-95dd-dcf70a183694.png)
