### PR TITLE
Allow users of components using withTheme to pass theme styles

### DIFF
--- a/src/styles/themer/withTheme.js
+++ b/src/styles/themer/withTheme.js
@@ -34,8 +34,8 @@ function withTheme(InnerComponent) {
       return (
         <InnerComponent
           ref={isStateless(InnerComponent) ? undefined : getRef}
-          {...this.props}
           snacksTheme={themer.themeConfig}
+          {...this.props}
         />
       )
     }


### PR DESCRIPTION
We initially didn't expose the `snacksTheme` prop to users
because we didn't need to, and smaller surface areas are usually
a good thing.

Recently we had a few use cases where we wanted to lock in a
particular theme for a subset of snacks components, so this commit
allows users to pass in a custom `snacksTheme` prop to any components
that use `withTheme`.

cc @mayukh-das 