### PR TITLE
allow snacksTheme prop to be overridden

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,9 @@ module.exports = {
     "es6": true,
     "jest": true
   },
+  "globals": {
+    "__DEV__": true
+  },
   "extends": [
     "eslint:recommended",
     "plugin:jsx-a11y/recommended"
@@ -18,15 +21,15 @@ module.exports = {
   },
   "plugins": [
     "react",
-     "jsx-a11y"
+    "jsx-a11y"
   ],
   "rules": {
     "strict": 0,
     "camelcase": "error",
-    "indent": [ "error", 2, { "SwitchCase": 1 }],
-    "linebreak-style": [ "error", "unix" ],
-    "quotes": [ "error", "single" ],
-    "semi": [ "error", "never" ],
+    "indent": ["error", 2, { "SwitchCase": 1 }],
+    "linebreak-style": ["error", "unix"],
+    "quotes": ["error", "single"],
+    "semi": ["error", "never"],
     "max-len": ["error", {
       "code": 120,
       "ignoreStrings": true,

--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
     "react-transition-group": "^2.2.1"
   },
   "jest": {
+    "globals": {
+      "__DEV__": true
+    },
     "moduleNameMapper": {
       "^utils": "<rootDir>/src/utils",
       "^styles": "<rootDir>/src/styles",

--- a/src/styles/themer/__tests__/withTheme.spec.js
+++ b/src/styles/themer/__tests__/withTheme.spec.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import withTheme from '../withTheme'
-import { themePropTypes } from '../utils'
+import { defaultTheme, themePropTypes } from '../utils'
 
 const TestComponent = withTheme(
   class extends React.Component { // eslint-disable-line react/prefer-stateless-function
@@ -29,3 +29,58 @@ it('renders without error with default theme', () => {
     .toJSON()
   expect(tree).toMatchSnapshot()
 })
+
+describe('while in production mode', () => {
+  beforeAll(() => {
+    global.__DEV__ = false
+  })
+
+  afterAll(() => {
+    global.__DEV__ = true
+  })
+
+  it('can be overridden', () => {
+    const testColor = 'red'
+    const tree = renderer
+      .create(
+        <TestComponent snacksTheme={{
+          colors: {
+            primaryBackground: testColor
+          }
+        }} />
+      ).toJSON()
+    expect(tree.props.style.backgroundColor).toBe(testColor)
+  })
+
+  it('falls back to active themer theme if props are invalid', () => {
+    [null, undefined].map((invalidTheme) => {
+      const tree = renderer
+        .create(
+          <TestComponent snacksTheme={invalidTheme} />
+        ).toJSON()
+      expect(tree.props.style.backgroundColor).toBe(defaultTheme.colors.primaryBackground)
+    })
+  })
+})
+
+describe('while in development mode', () => {
+  beforeEach(() => {
+    global.__DEV__ = true
+    // we can stop swallowing these when this is finished
+    // https://github.com/facebook/react/issues/11098
+    jest.spyOn(console, 'error')
+    global.console.error.mockImplementation(() => { })
+  })
+
+  afterEach(() => {
+    global.console.error.mockRestore()
+  })
+  it('throws an error on invalid snacksTheme', () => {
+    const createTree = () => renderer
+      .create(
+        <TestComponent snacksTheme={1} />
+      ).toJSON()
+    expect(() => createTree()).toThrow()
+  })
+})
+

--- a/src/styles/themer/withTheme.js
+++ b/src/styles/themer/withTheme.js
@@ -2,7 +2,7 @@
 // and passes down theme through props
 import React, { Component } from 'react'
 import themer from './index'
-import { themePropTypes } from './utils'
+import { cleanConfig, themePropTypes } from './utils'
 
 const isStateless = (Component) => {
   return !Component.prototype.render
@@ -33,10 +33,9 @@ function withTheme(InnerComponent) {
     validateSnacksTheme() {
       if (__DEV__) { // eslint-disable-line no-undef
         const { snacksTheme } = this.props
-        const snackType = typeof snacksTheme
-        const themeIsBad = Boolean(snacksTheme) && snackType !== 'object'
+        const themeIsBad = snacksTheme && !Object.keys(cleanConfig(snacksTheme)).length
         if (themeIsBad) {
-          throw new Error(`Recieved an invalid snacksTheme Prop. Expected undefined or an object and instead got ${snackType}`)
+          throw new Error(`Recieved an invalid snacksTheme Prop. Expected undefined or an object and instead got ${typeof snacksTheme}`)
         }
       }
     }

--- a/src/styles/themer/withTheme.js
+++ b/src/styles/themer/withTheme.js
@@ -18,10 +18,27 @@ function withTheme(InnerComponent) {
 
     componentDidMount() {
       this.unsubscribe = themer.subscribe(this.onThemeChange)
+      this.validateSnacksTheme()
     }
 
     componentWillUnmount() {
       this.unsubscribe()
+    }
+
+    themeIsValid() {
+      const { snacksTheme } = this.props
+      return Boolean(snacksTheme) && typeof snacksTheme === 'object'
+    }
+
+    validateSnacksTheme() {
+      if (__DEV__) { // eslint-disable-line no-undef
+        const { snacksTheme } = this.props
+        const snackType = typeof snacksTheme
+        const themeIsBad = Boolean(snacksTheme) && snackType !== 'object'
+        if (themeIsBad) {
+          throw new Error(`Recieved an invalid snacksTheme Prop. Expected undefined or an object and instead got ${snackType}`)
+        }
+      }
     }
 
     onThemeChange = () => {
@@ -30,12 +47,14 @@ function withTheme(InnerComponent) {
 
     render() {
       const getRef = (node) => this.wrapped = node
+      const { snacksTheme, ...rest } = this.props
+      const theme = this.themeIsValid() ? snacksTheme : themer.themeConfig
 
       return (
         <InnerComponent
           ref={isStateless(InnerComponent) ? undefined : getRef}
-          snacksTheme={themer.themeConfig}
-          {...this.props}
+          snacksTheme={theme}
+          {...rest}
         />
       )
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const webpack = require('webpack')
 
 module.exports = {
   mode: 'development',
@@ -20,6 +21,11 @@ module.exports = {
     library: 'Snacks',
     libraryTarget: 'umd'
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      __DEV__: JSON.stringify(true)
+    })
+  ],
   resolve: {
     alias: {
       utils: path.resolve(__dirname, 'src/utils'),


### PR DESCRIPTION
This PR will:
1. respect `snacksTheme` overrides
2. Throw errors in dev if the prop is overridden with anything other than an object.

Bonus - also some prettier changes to the eslintrc