### PR TITLE
Allow for Tooltip to become a controlled element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ jspm_packages
 .yarn-integrity
 
 .DS_Store
+
+# IDE
+.idea

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -31,7 +31,6 @@ class Tooltip extends PureComponent {
     size: 'small',
     onShow: noop,
     onDismiss: noop,
-    isVisible: false,
   }
 
   state = {
@@ -56,18 +55,19 @@ class Tooltip extends PureComponent {
   }
 
   renderTriggerElement() {
-    const { target } = this.props
+    const { target, isVisible } = this.props
     const { show } = this.state
 
     if (!target) { return }
+    const extraProps = isVisible == null ? { onClick: this.handleToggle.bind(this) } : {}
 
     return React.cloneElement(target, {
       ref: (node) => {
         this.trigger = node
       },
-      onClick: this.handleToggle.bind(this),
       'aria-haspopup': true,
-      'aria-expanded': show
+      'aria-expanded': isVisible || show,
+      ...extraProps
     })
   }
 

--- a/src/components/Tooltip/__tests__/Tooltip.spec.js
+++ b/src/components/Tooltip/__tests__/Tooltip.spec.js
@@ -81,6 +81,21 @@ describe('Tooltip', () => {
     expect(tooltip.state().show).toEqual(false)
   })
 
+  it('should change its internal state when element is uncontrolled', () => {
+    const tooltip = mount(
+      <Tooltip
+        target={(<button>TRIGGER</button>)}
+      />
+    )
+
+    expect(tooltip.state().show).toEqual(false)
+
+    const trigger = tooltip.find('button').last()
+    trigger.last().simulate('click')
+
+    expect(tooltip.state().show).toEqual(true)
+  })
+
   it('should not change its internal state when passing in false for isVisible', () => {
     const tooltip = mount(
       <Tooltip

--- a/src/components/Tooltip/__tests__/Tooltip.spec.js
+++ b/src/components/Tooltip/__tests__/Tooltip.spec.js
@@ -66,73 +66,49 @@ describe('Tooltip', () => {
     expect(onDismiss.calledOnce).toBe(true)
   })
 
-    it('should have true show state and true isVisible prop when simulating click', () => {
+  it('should not change its internal state if the component is controlled through isVisible', () => {
       
-      const tooltip = mount(
-        <Tooltip
-          target={(<button>TRIGGER</button>)}
-          placement='right'
-          size='small'
-          snacksStyle="secondary"
-          isVisible={true}
-        >
-          Right Secondary small
-        </Tooltip>
-      )
-      
-      const trigger = tooltip.find('button').last()
-      trigger.last().simulate('click')
-      expect(tooltip.props().isVisible).toEqual(true)
-      expect(tooltip.state().show).toEqual(true)
+    const tooltip = mount(
+      <Tooltip
+        target={(<button>TRIGGER</button>)}
+        isVisible={true}
+      />
+    )
+
+    const trigger = tooltip.find('button').last()
+    trigger.last().simulate('click')
+    expect(tooltip.props().isVisible).toEqual(true)
+    expect(tooltip.state().show).toEqual(false)
   })
 
-    it('should have false show state and true isVisible prop when not simulating click', () => {
+  it('should not change its internal state when passing in false for isVisible', () => {
+    const tooltip = mount(
+      <Tooltip
+        target={(<button>TRIGGER</button>)}
+        isVisible={false}
+      />
+    )
 
-      const tooltip = mount(
-        <Tooltip
-          target={(<button>TRIGGER</button>)}
-          placement='right'
-          size='small'
-          snacksStyle="secondary"
-          isVisible={true}
-        >
-          Right Secondary small
-        </Tooltip>
-      )
+    const trigger = tooltip.find('button').last()
+    trigger.last().simulate('click')
 
-      expect(tooltip.props().isVisible).toEqual(true)
-      expect(tooltip.state().show).toEqual(false)
-  })
-    
-
-    it('should have true show state and isVisible prop when passing in true' + 
-      'for isVisible and they should both be false when passing in false', () => {
-      
-      let isVisible = true
-      const tooltip = mount(
-        <Tooltip
-          target={(<button>TRIGGER</button>)}
-          placement='right'
-          size='small'
-          snacksStyle="secondary"
-          isVisible={isVisible}
-        >
-          Right Secondary small
-        </Tooltip>
-      )
-
-      const trigger = tooltip.find('button').last()
-      trigger.last().simulate('click')
-      
-      expect(tooltip.props().isVisible).toEqual(true)
-      expect(tooltip.state().show).toEqual(true)
-
-      trigger.last().simulate('click')
-      tooltip.props().isVisible = false
-      
-      expect(tooltip.props().isVisible).toEqual(false)
-      expect(tooltip.state().show).toEqual(false)
+    expect(tooltip.props().isVisible).toEqual(false)
+    expect(tooltip.state().show).toEqual(false)
   })
 
+
+  it('should have false show state and true isVisible prop when not simulating click', () => {
+
+    const tooltip = mount(
+      <Tooltip
+        target={(<button>TRIGGER</button>)}
+        isVisible={true}
+      >
+      </Tooltip>
+    )
+
+    expect(tooltip.props().isVisible).toEqual(true)
+    expect(tooltip.state().show).toEqual(false)
+  })
 
 })


### PR DESCRIPTION
Change the behavior of controlled Tooltip.

Currently the tooltip is shown if either isVisible is true or internal state is true. And a click controls internal state. This leads to a behavior where even if isVisible is set to false the Tooltip will show up on click.

I think if a Tooltip is controlled, it should not override its visibility flag with internal state.

Behavior after this change:
If isVisible is undefined or null, no change in behavior.
if isVisible is set to false or true it fully controls the visibility of the tooltip.