### PR TITLE
provide production value for __DEV__ global

### DIFF
--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin')
+const webpack = require('webpack')
 
 module.exports = {
   mode: 'production',
@@ -29,6 +30,11 @@ module.exports = {
       })
     ]
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      __DEV__: JSON.stringify(false)
+    })
+  ],
   output: {
     library: 'Snacks',
     libraryTarget: 'umd',


### PR DESCRIPTION
fixes an error where __DEV__ was undefined in the production build. `JSON.stringify(false)` is transpired as a boolean.

https://webpack.js.org/plugins/define-plugin/