### PR TITLE
Pass snacksTheme to child components in certain form elements

### DIFF
--- a/src/components/Forms/PhoneNumberField.js
+++ b/src/components/Forms/PhoneNumberField.js
@@ -263,6 +263,7 @@ class PhoneNumberField extends React.Component {
             hasError={hasError}
             htmlFor={inputId}
             style={{pointerEvents: 'none'}}
+            snacksTheme={snacksTheme}
           />
 
           <TextFieldHint

--- a/src/components/Forms/Select.js
+++ b/src/components/Forms/Select.js
@@ -282,6 +282,7 @@ class Select extends React.PureComponent {
             isActive={isOpen || isFocused}
             hasError={hasError}
             style={styles.floatingLabel}
+            snacksTheme={snacksTheme}
           />
 
           <div style={styles.labelContainer}>

--- a/src/components/Forms/TextField.js
+++ b/src/components/Forms/TextField.js
@@ -230,7 +230,6 @@ class TextField extends React.Component {
 
         <div style={styles.inputContainer}>
           <FloatingLabel
-            snacksTheme={snacksTheme}
             text={floatingLabelText}
             float={isFocused || hasValue}
             disabled={disabled}

--- a/src/components/Forms/TextField.js
+++ b/src/components/Forms/TextField.js
@@ -237,6 +237,7 @@ class TextField extends React.Component {
             isActive={isFocused}
             hasError={hasError}
             htmlFor={inputId}
+            snacksTheme={snacksTheme}
           />
 
           { hintText &&

--- a/src/components/Forms/__tests__/PhoneNumberField.spec.js
+++ b/src/components/Forms/__tests__/PhoneNumberField.spec.js
@@ -2,6 +2,7 @@ import React         from 'react'
 import { StyleRoot } from 'radium'
 import { mount } from 'enzyme'
 import toJson        from 'enzyme-to-json'
+import renderer from 'react-test-renderer'
 import PhoneNumberField  from '../PhoneNumberField'
 
 it('renders without error', () => {
@@ -130,4 +131,35 @@ it('fires the onChange prop', () => {
   // ensure the callback passes correct, updated phone value
   expect(onChange.mock.calls[1]).toEqual([expect.anything(), '1234567890', '(123) 456-7890'])
   expect(onChange.mock.calls.length).toBe(2)
+})
+
+it('uses a custom theme for all child components if one is provided', () => {
+  const customTheme = {
+    colors: {
+      action: 'green',
+      actionHover: 'darkgreen',
+      primaryBackground: 'white',
+      primaryForeground: 'green',
+      secondaryBackground: 'green',
+      secondaryForeground: 'white',
+      secondaryForegroundFocus: 'gray'
+    }
+  }
+
+  const wrapper = mount(
+    <StyleRoot>
+      <div>
+        <PhoneNumberField
+          id="test_id"
+          name="test"
+          floatingLabelText="Phone Number"
+          hintText="(555) 555-555"
+          onChange={() => {}}
+          snacksTheme={customTheme}
+        />
+      </div>
+    </StyleRoot>
+  )
+
+  expect(toJson(wrapper)).toMatchSnapshot()
 })

--- a/src/components/Forms/__tests__/Select.spec.js
+++ b/src/components/Forms/__tests__/Select.spec.js
@@ -121,3 +121,38 @@ it('should fire callbacks', () => {
   expect(onSelect.calledOnce).toBe(true)
   expect(onClose.calledOnce).toBe(true)
 })
+
+it('uses a custom theme for all child components if one is provided', () => {
+  const customTheme = {
+    colors: {
+      action: 'green',
+      actionHover: 'darkgreen',
+      primaryBackground: 'white',
+      primaryForeground: 'green',
+      secondaryBackground: 'green',
+      secondaryForeground: 'white',
+      secondaryForegroundFocus: 'gray'
+    }
+  }
+
+  const tree = renderer
+    .create(
+      <StyleRoot>
+        <Select
+          id="test_id"
+          name="country"
+          floatingLabelText="Country"
+          hintText="Select a country"
+          onOpen={() => {}}
+          onClose={() => {}}
+          onSelect={() => {}}
+          snacksTheme={customTheme}
+        >
+          <MenuItem label="United States" value="US" />
+        </Select>
+      </StyleRoot>
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/Forms/__tests__/TextField.spec.js
+++ b/src/components/Forms/__tests__/TextField.spec.js
@@ -87,3 +87,37 @@ it('fires the onChange prop', () => {
 
   expect(onChange.calledOnce).toBe(true)
 })
+
+it('uses a custom theme for all child components if one is provided', () => {
+  const customTheme = {
+    colors: {
+      action: 'green',
+      actionHover: 'darkgreen',
+      primaryBackground: 'white',
+      primaryForeground: 'green',
+      secondaryBackground: 'green',
+      secondaryForeground: 'white',
+      secondaryForegroundFocus: 'gray'
+    }
+  }
+
+  const tree = renderer
+    .create(
+      <StyleRoot>
+        <div>
+          <TextField
+            id="test_id"
+            name="test"
+            type="email"
+            floatingLabelText="Email"
+            hintText="Enter your email address"
+            onChange={() => {}}
+            snacksTheme={customTheme}
+          />
+        </div>
+      </StyleRoot>
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/Forms/__tests__/__snapshots__/PhoneNumberField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/PhoneNumberField.spec.js.snap
@@ -89,6 +89,19 @@ exports[`renders correctly 1`] = `
                   hasError={false}
                   htmlFor="test_id"
                   key=".0"
+                  snacksTheme={
+                    Object {
+                      "colors": Object {
+                        "action": "#43B02A",
+                        "actionHover": "#177D05",
+                        "primaryBackground": "#FFFFFF",
+                        "primaryForeground": "#43B02A",
+                        "secondaryBackground": "#43B02A",
+                        "secondaryForeground": "#FFFFFF",
+                        "secondaryForegroundFocus": "#757575",
+                      },
+                    }
+                  }
                   style={
                     Object {
                       "pointerEvents": "none",
@@ -377,6 +390,19 @@ exports[`renders correctly with focus state 1`] = `
                   htmlFor="test_id"
                   isActive={true}
                   key=".0"
+                  snacksTheme={
+                    Object {
+                      "colors": Object {
+                        "action": "#43B02A",
+                        "actionHover": "#177D05",
+                        "primaryBackground": "#FFFFFF",
+                        "primaryForeground": "#43B02A",
+                        "secondaryBackground": "#43B02A",
+                        "secondaryForeground": "#FFFFFF",
+                        "secondaryForegroundFocus": "#757575",
+                      },
+                    }
+                  }
                   style={
                     Object {
                       "pointerEvents": "none",
@@ -513,6 +539,321 @@ exports[`renders correctly with focus state 1`] = `
                         "WebkitTapHighlightColor": "rgba(0,0,0,0)",
                         "backgroundColor": "#FFFFFF",
                         "border": "1px solid #43B02A",
+                        "borderRadius": 4,
+                        "boxSizing": "border-box",
+                        "color": "#424242",
+                        "fontSize": 16,
+                        "height": 56,
+                        "margin": "0",
+                        "outline": "none",
+                        "padding": "25px 8px 8px 8px",
+                        "position": "relative",
+                        "width": "100%",
+                      }
+                    }
+                    type="tel"
+                  />
+                </t>
+              </div>
+              <ValidationError
+                inputId="test_id"
+                key=".2"
+                show={false}
+              >
+                <div
+                  aria-atomic={true}
+                  aria-live="assertive"
+                  data-radium={true}
+                  id="error_test_id"
+                  style={
+                    Object {
+                      "color": "#B30029",
+                      "display": "none",
+                      "fontSize": "12px",
+                      "marginLeft": "1px",
+                      "marginTop": "2px",
+                      "opacity": "0",
+                      "pointerEvents": "none",
+                      "textAlign": "left",
+                      "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                    }
+                  }
+                />
+              </ValidationError>
+              <HelperText
+                key=".3"
+              />
+            </div>
+          </PhoneNumberField>
+        </FormComponent>
+      </withTheme(FormComponent)>
+    </div>
+    <StyleSheet
+      key=".1"
+    >
+      <style
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "",
+          }
+        }
+      />
+    </StyleSheet>
+  </div>
+</StyleRoot>
+`;
+
+exports[`uses a custom theme for all child components if one is provided 1`] = `
+<StyleRoot>
+  <div
+    data-radium={true}
+  >
+    <div
+      key=".0"
+    >
+      <withTheme(FormComponent)
+        floatingLabelText="Phone Number"
+        hintText="(555) 555-555"
+        id="test_id"
+        name="test"
+        onChange={[Function]}
+        snacksTheme={
+          Object {
+            "colors": Object {
+              "action": "green",
+              "actionHover": "darkgreen",
+              "primaryBackground": "white",
+              "primaryForeground": "green",
+              "secondaryBackground": "green",
+              "secondaryForeground": "white",
+              "secondaryForegroundFocus": "gray",
+            },
+          }
+        }
+      >
+        <FormComponent
+          floatingLabelText="Phone Number"
+          hintText="(555) 555-555"
+          id="test_id"
+          name="test"
+          onChange={[Function]}
+          snacksTheme={
+            Object {
+              "colors": Object {
+                "action": "green",
+                "actionHover": "darkgreen",
+                "primaryBackground": "white",
+                "primaryForeground": "green",
+                "secondaryBackground": "green",
+                "secondaryForeground": "white",
+                "secondaryForegroundFocus": "gray",
+              },
+            }
+          }
+        >
+          <PhoneNumberField
+            autoComplete="on"
+            defaultValue={null}
+            disabled={false}
+            floatingLabelText="Phone Number"
+            hasError={false}
+            hintText="(555) 555-555"
+            id="test_id"
+            isValid={true}
+            name="test"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            serverError={null}
+            snacksTheme={
+              Object {
+                "colors": Object {
+                  "action": "green",
+                  "actionHover": "darkgreen",
+                  "primaryBackground": "white",
+                  "primaryForeground": "green",
+                  "secondaryBackground": "green",
+                  "secondaryForeground": "white",
+                  "secondaryForegroundFocus": "gray",
+                },
+              }
+            }
+          >
+            <div
+              data-radium={true}
+              style={
+                Object {
+                  "cursor": "auto",
+                  "display": "inline-block",
+                  "position": "relative",
+                  "width": 343,
+                }
+              }
+            >
+              <div
+                data-radium={true}
+                key=".1"
+                style={
+                  Object {
+                    "borderRadius": 4,
+                    "position": "relative",
+                  }
+                }
+              >
+                <withTheme(RadiumEnhancer)
+                  disabled={false}
+                  float={false}
+                  hasError={false}
+                  htmlFor="test_id"
+                  key=".0"
+                  snacksTheme={
+                    Object {
+                      "colors": Object {
+                        "action": "green",
+                        "actionHover": "darkgreen",
+                        "primaryBackground": "white",
+                        "primaryForeground": "green",
+                        "secondaryBackground": "green",
+                        "secondaryForeground": "white",
+                        "secondaryForegroundFocus": "gray",
+                      },
+                    }
+                  }
+                  style={
+                    Object {
+                      "pointerEvents": "none",
+                    }
+                  }
+                  text="Phone Number"
+                >
+                  <FloatingLabel
+                    disabled={false}
+                    float={false}
+                    hasError={false}
+                    htmlFor="test_id"
+                    snacksTheme={
+                      Object {
+                        "colors": Object {
+                          "action": "green",
+                          "actionHover": "darkgreen",
+                          "primaryBackground": "white",
+                          "primaryForeground": "green",
+                          "secondaryBackground": "green",
+                          "secondaryForeground": "white",
+                          "secondaryForegroundFocus": "gray",
+                        },
+                      }
+                    }
+                    style={
+                      Object {
+                        "pointerEvents": "none",
+                      }
+                    }
+                    text="Phone Number"
+                  >
+                    <label
+                      data-radium={true}
+                      htmlFor="test_id"
+                      style={
+                        Object {
+                          "color": "#757575",
+                          "cursor": "text",
+                          "fontSize": "16px",
+                          "margin": "0",
+                          "pointerEvents": "none",
+                          "position": "absolute",
+                          "transform": "scale(1) translate(8px, 17px)",
+                          "transformOrigin": "left top",
+                          "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "userSelect": "none",
+                          "zIndex": 1,
+                        }
+                      }
+                    >
+                      Phone Number
+                    </label>
+                  </FloatingLabel>
+                </withTheme(RadiumEnhancer)>
+                <TextFieldHint
+                  disabled={false}
+                  key=".1"
+                  text="(555) 555-555"
+                >
+                  <div
+                    data-radium={true}
+                    style={
+                      Object {
+                        "color": "#BDBDBD",
+                        "cursor": "inherit",
+                        "fontSize": "16px",
+                        "opacity": 0,
+                        "pointerEvents": "none",
+                        "position": "absolute",
+                        "transform": "scale(1) translate(9px, 26px)",
+                        "transformOrigin": "left top",
+                        "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "zIndex": 1,
+                      }
+                    }
+                  >
+                    (555) 555-555
+                  </div>
+                </TextFieldHint>
+                <t
+                  aria-invalid={false}
+                  autoComplete="on"
+                  defaultValue={null}
+                  disabled={false}
+                  guide={false}
+                  id="test_id"
+                  keepCharPositions={true}
+                  key=".2"
+                  mask={
+                    Array [
+                      "(",
+                      /\\[1-9\\]/,
+                      /\\\\d/,
+                      /\\\\d/,
+                      ")",
+                      " ",
+                      /\\\\d/,
+                      /\\\\d/,
+                      /\\\\d/,
+                      "-",
+                      /\\\\d/,
+                      /\\\\d/,
+                      /\\\\d/,
+                      /\\\\d/,
+                    ]
+                  }
+                  name="test"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  placeholder=""
+                  render={[Function]}
+                  type="tel"
+                >
+                  <input
+                    aria-invalid={false}
+                    autoComplete="on"
+                    defaultValue={null}
+                    disabled={false}
+                    id="test_id"
+                    name="test"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    placeholder=""
+                    style={
+                      Object {
+                        "WebkitOpacity": 1,
+                        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+                        "backgroundColor": "#FFFFFF",
+                        "border": "solid 1px #BDBDBD",
                         "borderRadius": 4,
                         "boxSizing": "border-box",
                         "color": "#424242",

--- a/src/components/Forms/__tests__/__snapshots__/Select.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/Select.spec.js.snap
@@ -1375,3 +1375,304 @@ exports[`renders invalid Select correctly 1`] = `
   />
 </div>
 `;
+
+exports[`uses a custom theme for all child components if one is provided 1`] = `
+<div
+  data-radium={true}
+>
+  <div
+    data-radium={true}
+    style={
+      Object {
+        "display": "inline-block",
+        "position": "relative",
+        "width": "343px",
+      }
+    }
+  >
+    <div
+      data-radium={true}
+    >
+      <div
+        data-radium={true}
+        onKeyDown={[Function]}
+        style={undefined}
+      >
+        <div
+          data-radium={true}
+          style={
+            Object {
+              "position": "relative",
+            }
+          }
+        >
+          <div
+            aria-expanded={false}
+            aria-haspopup={true}
+            data-radium={true}
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+          >
+            <div
+              aria-invalid={false}
+              aria-required={undefined}
+              data-radium={true}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              style={
+                Object {
+                  "WebkitOpacity": 1,
+                  "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+                  "backgroundColor": "#FFF",
+                  "border": "solid 1px #BDBDBD",
+                  "borderRadius": "4px",
+                  "boxSizing": "border-box",
+                  "color": "#424242",
+                  "fontSize": "16px",
+                  "height": "56px",
+                  "margin": "0",
+                  "outline": "none",
+                  "padding": "25px 25px 8px 8px",
+                  "position": "relative",
+                }
+              }
+              tabIndex={0}
+            >
+              <label
+                data-radium={true}
+                htmlFor={undefined}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "color": "#757575",
+                    "cursor": "text",
+                    "fontSize": "16px",
+                    "left": 0,
+                    "margin": "0",
+                    "pointerEvents": "auto",
+                    "position": "absolute",
+                    "top": 0,
+                    "transform": "scale(1) translate(8px, 17px)",
+                    "transformOrigin": "left top",
+                    "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                    "userSelect": "none",
+                    "zIndex": 1,
+                  }
+                }
+              >
+                Country
+              </label>
+              <div
+                data-radium={true}
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "overflow": "hidden",
+                    "textOverflow": "ellipsis",
+                    "userSelect": "none",
+                    "whiteSpace": "nowrap",
+                  }
+                }
+              >
+                <div
+                  data-radium={true}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  style={
+                    Object {
+                      "color": "#BDBDBD",
+                      "cursor": "inherit",
+                      "fontSize": "16px",
+                      "left": 0,
+                      "opacity": 0,
+                      "pointerEvents": "none",
+                      "position": "absolute",
+                      "top": 0,
+                      "transform": "scale(1) translate(9px, 26px)",
+                      "transformOrigin": "left top",
+                      "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                      "zIndex": 1,
+                    }
+                  }
+                >
+                  Select a country
+                </div>
+              </div>
+              <div
+                data-radium={true}
+                style={
+                  Object {
+                    "display": "flex",
+                    "flexDirection": "column",
+                    "position": "absolute",
+                    "right": "8px",
+                    "top": "22px",
+                    "userSelect": "none",
+                  }
+                }
+              >
+                <i
+                  aria-hidden={true}
+                  data-radium={true}
+                  onClick={undefined}
+                  style={
+                    Object {
+                      "color": "green",
+                      "fontFamily": "ic-icons",
+                      "fontSize": "16px",
+                      "fontSmoothing": "antialiased",
+                      "fontStyle": "normal",
+                      "fontVariant": "normal",
+                      "fontWeight": "normal",
+                      "lineHeight": "1",
+                      "osxFontSmoothing": "grayscale",
+                      "position": "relative",
+                      "speak": "none",
+                      "textTransform": "none",
+                      "transition": "transform 100ms",
+                      "userSelect": "none",
+                    }
+                  }
+                >
+                  
+                </i>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          data-radium={true}
+          style={
+            Object {
+              "display": "block",
+              "pointerEvents": "none",
+              "position": "absolute",
+              "width": "100%",
+              "zIndex": -9000,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "overflowX": "visible",
+                "overflowY": "hidden",
+                "padding": "2px 5px 5px",
+                "transform": "translateX(-5px)",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "transform": "translateY(-30px)",
+                  "transition": "all 200ms ease-in-out",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "opacity": 0,
+                    "transition": "all 200ms ease-in-out",
+                  }
+                }
+              >
+                <div
+                  aria-hidden={true}
+                  onBlur={[Function]}
+                  onKeyDown={[Function]}
+                  role="menu"
+                  style={
+                    Object {
+                      "backgroundColor": "#ffffff",
+                      "borderRadius": "4px",
+                      "boxShadow": "0 3px 10px 0 rgba(0, 0, 0, 0.16), 0 3px 10px 0 rgba(0, 0, 0, 0.23)",
+                      "display": "inline-block",
+                      "maxHeight": "500px",
+                      "outline": "none",
+                      "overflowY": "auto",
+                      "padding": "8px 0",
+                      "userSelect": "none",
+                      "width": "100%",
+                    }
+                  }
+                  tabIndex={-1}
+                >
+                  <div
+                    data-radium={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    role="menuitem"
+                    style={
+                      Object {
+                        "backgroundColor": "#ffffff",
+                        "padding": "16px 0",
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      data-radium={true}
+                      style={
+                        Object {
+                          "display": "table",
+                        }
+                      }
+                    >
+                      <div
+                        data-radium={true}
+                        style={
+                          Object {
+                            "padding": "0 16px",
+                            "whiteSpace": "nowrap",
+                          }
+                        }
+                      >
+                        United States
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-atomic={true}
+        aria-live="assertive"
+        data-radium={true}
+        id="error_test_id"
+        style={
+          Object {
+            "color": "#B30029",
+            "display": "none",
+            "fontSize": "12px",
+            "marginLeft": "1px",
+            "marginTop": "2px",
+            "opacity": "0",
+            "pointerEvents": "none",
+            "textAlign": "left",
+            "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+          }
+        }
+      />
+    </div>
+  </div>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;

--- a/src/components/Forms/__tests__/__snapshots__/TextField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/TextField.spec.js.snap
@@ -132,3 +132,136 @@ exports[`renders TextField correctly 1`] = `
   />
 </div>
 `;
+
+exports[`uses a custom theme for all child components if one is provided 1`] = `
+<div
+  data-radium={true}
+>
+  <div>
+    <div
+      data-radium={true}
+      style={
+        Object {
+          "cursor": "auto",
+          "display": "inline-block",
+          "position": "relative",
+          "width": "343px",
+        }
+      }
+    >
+      <div
+        data-radium={true}
+        style={
+          Object {
+            "borderRadius": "4px",
+            "position": "relative",
+          }
+        }
+      >
+        <label
+          data-radium={true}
+          htmlFor="test_id"
+          style={
+            Object {
+              "color": "#757575",
+              "cursor": "text",
+              "fontSize": "16px",
+              "margin": "0",
+              "pointerEvents": "auto",
+              "position": "absolute",
+              "transform": "scale(1) translate(8px, 17px)",
+              "transformOrigin": "left top",
+              "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "userSelect": "none",
+              "zIndex": 1,
+            }
+          }
+        >
+          Email
+        </label>
+        <div
+          data-radium={true}
+          style={
+            Object {
+              "color": "#BDBDBD",
+              "cursor": "inherit",
+              "fontSize": "16px",
+              "opacity": 0,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "transform": "scale(1) translate(9px, 26px)",
+              "transformOrigin": "left top",
+              "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "zIndex": 1,
+            }
+          }
+        >
+          Enter your email address
+        </div>
+        <input
+          aria-describedby={null}
+          aria-invalid={false}
+          aria-required={undefined}
+          autoComplete="on"
+          data-radium={true}
+          defaultValue={null}
+          disabled={false}
+          id="test_id"
+          name="test"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          placeholder=""
+          style={
+            Object {
+              "WebkitOpacity": 1,
+              "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+              "backgroundColor": "#FFF",
+              "border": "solid 1px #BDBDBD",
+              "borderRadius": "4px",
+              "boxSizing": "border-box",
+              "color": "#424242",
+              "fontSize": "16px",
+              "height": "56px",
+              "margin": "0",
+              "outline": "none",
+              "padding": "25px 8px 8px 8px",
+              "position": "relative",
+              "width": "100%",
+            }
+          }
+          type="email"
+          value={undefined}
+        />
+      </div>
+      <div
+        aria-atomic={true}
+        aria-live="assertive"
+        data-radium={true}
+        id="error_test_id"
+        style={
+          Object {
+            "color": "#B30029",
+            "display": "none",
+            "fontSize": "12px",
+            "marginLeft": "1px",
+            "marginTop": "2px",
+            "opacity": "0",
+            "pointerEvents": "none",
+            "textAlign": "left",
+            "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+          }
+        }
+      />
+    </div>
+  </div>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;


### PR DESCRIPTION
#196 allowed users to pass in a custom `snacksTheme` object. `Select`, `TextField`, and `PhoneNumberInput` all render `FloatingLabel` as a child component, which itself is wrapped with `withTheme`.

e.g. if a custom `snacksTheme` prop was provided to `TextField`, those theme values would be respected everywhere expect `FloatingLabel`, which was still reading it's values from `withTheme` (and by extension `themer`).

This commit passes the `snacksTheme` prop explicitly to `FloatingLabel` in those components so the theme colors are applied everywhere.