### PR TITLE
Make radio/checkbox input element styleable

### DIFF
--- a/src/base/RadioCheckboxBase.js
+++ b/src/base/RadioCheckboxBase.js
@@ -63,13 +63,14 @@ class RadioCheckboxBase extends React.PureComponent {
     btnType       : PropTypes.oneOf(['radio', 'checkbox']).isRequired,
     isDisabled    : PropTypes.bool,
     children      : PropTypes.string,
-    id            : PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    id            : PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     isSelected    : PropTypes.bool,
     onChange      : PropTypes.func,
     style         : PropTypes.shape({
       button        : PropTypes.object,
       label         : PropTypes.object,
       wrapEl        : PropTypes.object,
+      inputBtn      : PropTypes.object,
     }),
     snacksTheme   : themePropTypes,
     value         : PropTypes.string,
@@ -121,7 +122,7 @@ class RadioCheckboxBase extends React.PureComponent {
           id={id}
           type={btnType}
           onChange={this.handleChange}
-          style={STYLE.inputBtn}
+          style={{...STYLE.inputBtn, ...style.inputBtn}}
           value={value}
           checked={isSelected}
           disabled={isDisabled}

--- a/src/components/Buttons/Checkbox.js
+++ b/src/components/Buttons/Checkbox.js
@@ -26,7 +26,7 @@ Checkbox.propTypes = {
     label         :PropTypes.string,
   }),
   children      : PropTypes.string,
-  id            : PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  id            : PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   isDisabled    : PropTypes.bool,
   isSelected    : PropTypes.bool,
   name          : PropTypes.string,

--- a/src/components/Buttons/Radio.js
+++ b/src/components/Buttons/Radio.js
@@ -26,7 +26,7 @@ Radio.propTypes = {
     label         :PropTypes.string,
   }),
   children      : PropTypes.string,
-  id            : PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  id            : PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   isDisabled    : PropTypes.bool,
   isSelected    : PropTypes.bool,
   name          : PropTypes.string,

--- a/src/components/Buttons/__tests__/Radio.spec.js
+++ b/src/components/Buttons/__tests__/Radio.spec.js
@@ -56,7 +56,8 @@ describe('Radio', () => {
         style: {
           wrapEl: {background: 'pink'},
           button: {border: '2px solid purple' },
-          label: {color: 'green'}
+          label: {color: 'green'},
+          inputBtn: {cursor: 'pointer'}
         },
       },
       {

--- a/src/components/Buttons/__tests__/__snapshots__/Radio.spec.js.snap
+++ b/src/components/Buttons/__tests__/__snapshots__/Radio.spec.js.snap
@@ -110,6 +110,7 @@ exports[`Radio incorporates user styles if passed 1`] = `
           "WebkitAppearance": "none",
           "appearance": "none",
           "backgroundImage": "none",
+          "cursor": "pointer",
           "height": 22,
           "left": 0,
           "opacity": 0,


### PR DESCRIPTION
This resolves issues where global input CSS rules interfere with Snacks.

Also, this commit marks the id prop as required for radio and checkbox. In the past, if you attempt to use either control without a valid ID and label, it would result in broken controls.

Fixes #206 and #207