### PR TITLE
Add Pill component

### DIFF
--- a/src/components/Pill/Pill.js
+++ b/src/components/Pill/Pill.js
@@ -1,17 +1,15 @@
 import React from 'react'
-import { colors } from '../../styles'
 import { spacings } from '../../styles/spacing'
 import PropTypes from 'prop-types'
 import Radium from 'radium'
 import withTheme from '../../styles/themer/withTheme'
 
 const getStyles = props => {
-  const { color, hovorColor } = props
-  const restingColor = colors[color]
-  const onHoverColor = colors[hovorColor] || color
+  const { color: colorProp, snacksTheme } = props
+  const color = snacksTheme.colors[colorProp] || colorProp
 
   return {
-    backgroundColor: restingColor,
+    backgroundColor: color,
     color: 'white',
     borderRadius: spacings.SM,
     padding: `0 ${spacings.XS}px`,
@@ -19,10 +17,6 @@ const getStyles = props => {
     textAlign: 'center',
     display: 'inline-block',
     width: 'auto',
-
-    ':hover': {
-      color: onHoverColor,
-    }
   }
 }
 
@@ -40,7 +34,7 @@ const Pill = props => {
 }
 
 Pill.propTypes = {
-  /** Color of the pill. */
+  /** Color of the pill. can be hex value or themer color key as string */
   color: PropTypes.string,
 
   /** The pill's text content. */

--- a/src/components/Pill/Pill.js
+++ b/src/components/Pill/Pill.js
@@ -1,0 +1,60 @@
+import React from 'react'
+import { colors } from '../../styles'
+import { spacings } from '../../styles/spacing'
+import PropTypes from 'prop-types'
+import Radium from 'radium'
+import withTheme from '../../styles/themer/withTheme'
+
+const getStyles = props => {
+  const { color, hovorColor } = props
+  const restingColor = colors[color]
+  const onHoverColor = colors[hovorColor] || color
+
+  return {
+    backgroundColor: restingColor,
+    color: 'white',
+    borderRadius: spacings.SM,
+    padding: `0 ${spacings.XS}px`,
+    margin: `${spacings.XS}px`,
+    textAlign: 'center',
+    display: 'inline-block',
+    width: 'auto',
+
+    ':hover': {
+      color: onHoverColor,
+    }
+  }
+}
+
+const Pill = props => {
+  const styles = getStyles(props)
+
+  return (
+    <div
+      style={[styles, props.style]}
+      {...props.elementAttributes}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+Pill.propTypes = {
+  /** Color of the pill. */
+  color: PropTypes.string,
+
+  /** The pill's text content. */
+  children: PropTypes.node.isRequired,
+
+  /** Optional styles. */
+  style: PropTypes.object,
+
+  /** Any addional props. */
+  elementAttributes: PropTypes.object
+}
+
+Pill.defaultProps = {
+  color: '#CC0033'
+}
+
+export default withTheme(Radium(Pill))

--- a/src/components/Pill/__tests__/Pill.spec.js
+++ b/src/components/Pill/__tests__/Pill.spec.js
@@ -6,7 +6,7 @@ describe('Pill', () => {
   it('renders without throwing', () => {
     const tree = renderer
       .create(
-          <Pill>HI</Pill>
+        <Pill>HI</Pill>
       )
       .toJSON()
     expect(tree).toMatchSnapshot()
@@ -15,7 +15,7 @@ describe('Pill', () => {
   it('renders correctly when style overrides are provided', () => {
     const tree = renderer
       .create(
-          <Pill style={{ textDecoration: 'underline' }}>HI</Pill>
+        <Pill style={{ textDecoration: 'underline' }}>HI</Pill>
       )
       .toJSON()
     expect(tree).toMatchSnapshot()
@@ -24,7 +24,7 @@ describe('Pill', () => {
   it('applies the elementAttributes prop correctly', () => {
     const tree = renderer
       .create(
-          <Pill elementAttributes={{ 'aria-label': 'foo' }}>HI</Pill>
+        <Pill elementAttributes={{ 'aria-label': 'foo' }}>HI</Pill>
       )
       .toJSON()
 

--- a/src/components/Pill/__tests__/Pill.spec.js
+++ b/src/components/Pill/__tests__/Pill.spec.js
@@ -1,0 +1,33 @@
+import Pill from '../Pill'
+import React from 'react'
+import renderer from 'react-test-renderer'
+
+describe('Pill', () => {
+  it('renders without throwing', () => {
+    const tree = renderer
+      .create(
+          <Pill>HI</Pill>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders correctly when style overrides are provided', () => {
+    const tree = renderer
+      .create(
+          <Pill style={{ textDecoration: 'underline' }}>HI</Pill>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('applies the elementAttributes prop correctly', () => {
+    const tree = renderer
+      .create(
+          <Pill elementAttributes={{ 'aria-label': 'foo' }}>HI</Pill>
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/Pill/__tests__/__snapshots__/Pill.spec.js.snap
+++ b/src/components/Pill/__tests__/__snapshots__/Pill.spec.js.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pill applies the elementAttributes prop correctly 1`] = `
+<div
+  aria-label="foo"
+  data-radium={true}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  style={
+    Object {
+      "backgroundColor": undefined,
+      "borderRadius": 16,
+      "color": "white",
+      "display": "inline-block",
+      "margin": "8px",
+      "padding": "0 8px",
+      "textAlign": "center",
+      "width": "auto",
+    }
+  }
+>
+  HI
+</div>
+`;
+
+exports[`Pill renders correctly when style overrides are provided 1`] = `
+<div
+  data-radium={true}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  style={
+    Object {
+      "backgroundColor": undefined,
+      "borderRadius": 16,
+      "color": "white",
+      "display": "inline-block",
+      "margin": "8px",
+      "padding": "0 8px",
+      "textAlign": "center",
+      "textDecoration": "underline",
+      "width": "auto",
+    }
+  }
+>
+  HI
+</div>
+`;
+
+exports[`Pill renders without throwing 1`] = `
+<div
+  data-radium={true}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  style={
+    Object {
+      "backgroundColor": undefined,
+      "borderRadius": 16,
+      "color": "white",
+      "display": "inline-block",
+      "margin": "8px",
+      "padding": "0 8px",
+      "textAlign": "center",
+      "width": "auto",
+    }
+  }
+>
+  HI
+</div>
+`;

--- a/src/components/Pill/__tests__/__snapshots__/Pill.spec.js.snap
+++ b/src/components/Pill/__tests__/__snapshots__/Pill.spec.js.snap
@@ -4,11 +4,9 @@ exports[`Pill applies the elementAttributes prop correctly 1`] = `
 <div
   aria-label="foo"
   data-radium={true}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
   style={
     Object {
-      "backgroundColor": undefined,
+      "backgroundColor": "#CC0033",
       "borderRadius": 16,
       "color": "white",
       "display": "inline-block",
@@ -26,11 +24,9 @@ exports[`Pill applies the elementAttributes prop correctly 1`] = `
 exports[`Pill renders correctly when style overrides are provided 1`] = `
 <div
   data-radium={true}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
   style={
     Object {
-      "backgroundColor": undefined,
+      "backgroundColor": "#CC0033",
       "borderRadius": 16,
       "color": "white",
       "display": "inline-block",
@@ -49,11 +45,9 @@ exports[`Pill renders correctly when style overrides are provided 1`] = `
 exports[`Pill renders without throwing 1`] = `
 <div
   data-radium={true}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
   style={
     Object {
-      "backgroundColor": undefined,
+      "backgroundColor": "#CC0033",
       "borderRadius": 16,
       "color": "white",
       "display": "inline-block",

--- a/src/components/Pill/docs/Pill.md
+++ b/src/components/Pill/docs/Pill.md
@@ -1,33 +1,44 @@
 ### Pill example:
+```jsx
+const defaultTheme = require('../../../styles/themer/utils').defaultTheme;
+const colors = require('../../../styles/colors').default;
 
+const internalTrackStyles = {
+  RightArrow: {
+    backgroundColor: 'blue'
+  }
+}
 
-    internalTrackStyles = {
-      RightArrow: {
-        backgroundColor: 'blue'
-      }
-    }
+const styles = {
+  padding: '8px 20px',
+  marginRight: '5px',
+  fontSize: '24px',
+  borderRadius: '4px',
+  backgroundColor: '#eee',
+  color: '#43B02A',
+  top: '8px'
+};
+<div>
+  <h3>Passing in theme color keys </h3>
+  <div style={{ height: '56px' }}>
+    <ScrollTrack styles={internalTrackStyles}>
+    <div style={{ padding: '8px 0' }}>
+      {Object.keys(defaultTheme.colors).map(color => (
+        <Pill color={color} style={{margin: '0.5rem'}}>{color}</Pill>
+      ))}
+      </div>
+    </ScrollTrack>
+  </div>
 
-    styles = { padding: '8px 20px', marginRight: '5px', fontSize: '24px', borderRadius: '4px', backgroundColor: '#eee', color: '#43B02A', top: '8px' };
-    <div style={{ height: '56px' }}>
-      <ScrollTrack styles={internalTrackStyles}>
-        <div style={{ padding: '8px 0' }}>
-          <Pill color="GREEN_700" style={{margin: '0.5rem'}}>GREEN_700</Pill>
-          <Pill color="GREEN_600" style={{margin: '0.5rem'}}>GREEN_600</Pill>
-          <Pill color="GREEN_500" style={{margin: '0.5rem'}}>GREEN_500</Pill>
-          <Pill color="GREEN_400" style={{margin: '0.5rem'}}>GREEN_400</Pill>
-          <Pill color="GREEN_300" style={{margin: '0.5rem'}}>GREEN_300</Pill>
-          <Pill color="GRAY_93" style={{margin: '0.5rem', color: 'black'}}>GRAY_93</Pill>
-          <Pill color="GRAY_88" style={{margin: '0.5rem'}}>GRAY_88</Pill>
-          <Pill color="GRAY_74" style={{margin: '0.5rem'}}>GRAY_74</Pill>
-          <Pill color="GRAY_46" style={{margin: '0.5rem'}}>GRAY_46</Pill>
-          <Pill color="GRAY_20" style={{margin: '0.5rem'}}>GRAY_20</Pill>
-          <Pill color="GRAY_13" style={{margin: '0.5rem'}}>GRAY_13</Pill>
-
-          <Pill color="RED_700" style={{margin: '0.5rem'}}>RED_700</Pill>
-          <Pill color="RED_600" style={{margin: '0.5rem'}}>RED_600</Pill>
-          <Pill color="RED_500" style={{margin: '0.5rem'}}>RED_500</Pill>
-          <Pill color="RED_400" style={{margin: '0.5rem'}}>RED_400</Pill>
-          <Pill color="RED_300" style={{margin: '0.5rem'}}>RED_300</Pill>
-          </div>
-      </ScrollTrack>
-    </div>
+  <h3>Passing in Hex values</h3>
+  <div style={{ height: '56px' }}>
+    <ScrollTrack styles={internalTrackStyles}>
+    <div style={{ padding: '8px 0' }}>
+      {Object.values(colors).map(color => (
+        <Pill color={color} style={{margin: '0.5rem'}}>{color}</Pill>
+      ))}
+      </div>
+    </ScrollTrack>
+  </div>
+</div>
+```

--- a/src/components/Pill/docs/Pill.md
+++ b/src/components/Pill/docs/Pill.md
@@ -1,0 +1,33 @@
+### Pill example:
+
+
+    internalTrackStyles = {
+      RightArrow: {
+        backgroundColor: 'blue'
+      }
+    }
+
+    styles = { padding: '8px 20px', marginRight: '5px', fontSize: '24px', borderRadius: '4px', backgroundColor: '#eee', color: '#43B02A', top: '8px' };
+    <div style={{ height: '56px' }}>
+      <ScrollTrack styles={internalTrackStyles}>
+        <div style={{ padding: '8px 0' }}>
+          <Pill color="GREEN_700" style={{margin: '0.5rem'}}>GREEN_700</Pill>
+          <Pill color="GREEN_600" style={{margin: '0.5rem'}}>GREEN_600</Pill>
+          <Pill color="GREEN_500" style={{margin: '0.5rem'}}>GREEN_500</Pill>
+          <Pill color="GREEN_400" style={{margin: '0.5rem'}}>GREEN_400</Pill>
+          <Pill color="GREEN_300" style={{margin: '0.5rem'}}>GREEN_300</Pill>
+          <Pill color="GRAY_93" style={{margin: '0.5rem', color: 'black'}}>GRAY_93</Pill>
+          <Pill color="GRAY_88" style={{margin: '0.5rem'}}>GRAY_88</Pill>
+          <Pill color="GRAY_74" style={{margin: '0.5rem'}}>GRAY_74</Pill>
+          <Pill color="GRAY_46" style={{margin: '0.5rem'}}>GRAY_46</Pill>
+          <Pill color="GRAY_20" style={{margin: '0.5rem'}}>GRAY_20</Pill>
+          <Pill color="GRAY_13" style={{margin: '0.5rem'}}>GRAY_13</Pill>
+
+          <Pill color="RED_700" style={{margin: '0.5rem'}}>RED_700</Pill>
+          <Pill color="RED_600" style={{margin: '0.5rem'}}>RED_600</Pill>
+          <Pill color="RED_500" style={{margin: '0.5rem'}}>RED_500</Pill>
+          <Pill color="RED_400" style={{margin: '0.5rem'}}>RED_400</Pill>
+          <Pill color="RED_300" style={{margin: '0.5rem'}}>RED_300</Pill>
+          </div>
+      </ScrollTrack>
+    </div>

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -104,6 +104,10 @@ module.exports = {
           components: 'src/components/NavigationPills/[A-Z]*.js'
         },
         {
+          name: 'Pill',
+          components: 'src/components/Pill/Pill.js'
+        },
+        {
           name: 'ScrollTrack',
           components: 'src/components/ScrollTrack/[A-Z]*.js'
         },


### PR DESCRIPTION
This PR adds the `Pill` Component to snacks. The one question I had was around the color API. Currently it will throw a proptype warning if it is not a color in our styleguide which would ensure we are staying on brand while using this component. This may not be what we want moving forwards @mmarcuccio @dcocchia thoughts?

<img width="1412" alt="screen shot 2018-08-21 at 11 06 18 pm" src="https://user-images.githubusercontent.com/3149916/44440613-e5919180-a596-11e8-94da-b3187bc576aa.png">
