### PR TITLE
export Pill component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import Icon from './components/Icon/Icon'
 import SVGIcon from './components/SVGIcon/SVGIcon'
 import Link from './components/Link/Link'
 import LoadingBox from './components/Loading/LoadingBox'
+import Pill from './components/Pill/Pill'
 import NavigationPill from './components/NavigationPills/NavigationPill'
 import NavigationPills from './components/NavigationPills/NavigationPills'
 import Normalize from './styles/Normalize'
@@ -78,6 +79,7 @@ export {
   Slide,
 
   // components
+  Pill,
   Tooltip,
   Button,
   CircleButton,


### PR DESCRIPTION
This allows the Pill component to be used. To verify I built the package and pasted the dist in my node modules, the pill rendered without error.