### PR TITLE
position ToolTip component correctly, regardless of css translations

### DIFF
--- a/src/components/Tooltip/TooltipPosition.js
+++ b/src/components/Tooltip/TooltipPosition.js
@@ -46,18 +46,10 @@ class TooltipPosition extends PureComponent {
   getRect(node) {
     const container = node.getBoundingClientRect()
     const offset = {
-      top: 0,
-      left: 0,
+      top: container.top + window.pageYOffset,
+      left: container.left + window.pageXOffset,
       width: container.width || node.offsetWidth,
       height: container.height || node.offsetHeight
-    }
-    let offsetEl = node
-    // Calculate offset relative to document.
-    // Need to traverse offset for all parents
-    while (offsetEl) {
-      offset.top += offsetEl.offsetTop
-      offset.left += offsetEl.offsetLeft
-      offsetEl = offsetEl.offsetParent
     }
 
     return offset


### PR DESCRIPTION
The Tooltip component currently calculates styles incorrectly if there is a css transform translate applied in the node ancestry (think places like the checkout sidebar). This PR fixes that

Fixes #224 

![screen recording 2018-08-28 at 04 58 pm](https://user-images.githubusercontent.com/3149916/44750826-7c54d580-aae4-11e8-85fc-300b534436e4.gif)
