### PR TITLE
Fix checkbox/radio button label vertical alignment

### DIFF
--- a/src/base/RadioCheckboxBase.js
+++ b/src/base/RadioCheckboxBase.js
@@ -27,6 +27,7 @@ const STYLE = {
   },
   label: {
     marginLeft: 10,
+    lineHeight: `${INPUT_BTN_SIZE}px`,
   },
   wrapEl: {
     display: 'flex',

--- a/src/components/Buttons/__tests__/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/Buttons/__tests__/__snapshots__/Checkbox.spec.js.snap
@@ -58,6 +58,7 @@ exports[`Checkbox generates a label if a child prop of text is supplied 1`] = `
     htmlFor={1}
     style={
       Object {
+        "lineHeight": "22px",
         "marginLeft": 10,
       }
     }
@@ -128,6 +129,7 @@ exports[`Checkbox incorporates user style if passed 1`] = `
     style={
       Object {
         "color": "green",
+        "lineHeight": "22px",
         "marginLeft": 10,
       }
     }
@@ -195,6 +197,7 @@ exports[`Checkbox incorporates user style if passed 2`] = `
     htmlFor={2}
     style={
       Object {
+        "lineHeight": "22px",
         "marginLeft": 10,
       }
     }

--- a/src/components/Buttons/__tests__/__snapshots__/Radio.spec.js.snap
+++ b/src/components/Buttons/__tests__/__snapshots__/Radio.spec.js.snap
@@ -58,6 +58,7 @@ exports[`Radio generates a label if a child prop of text is supplied 1`] = `
     htmlFor={1}
     style={
       Object {
+        "lineHeight": "22px",
         "marginLeft": 10,
       }
     }
@@ -129,6 +130,7 @@ exports[`Radio incorporates user styles if passed 1`] = `
     style={
       Object {
         "color": "green",
+        "lineHeight": "22px",
         "marginLeft": 10,
       }
     }
@@ -196,6 +198,7 @@ exports[`Radio incorporates user styles if passed 2`] = `
     htmlFor={2}
     style={
       Object {
+        "lineHeight": "22px",
         "marginLeft": 10,
       }
     }

--- a/src/components/Buttons/docs/Checkbox.md
+++ b/src/components/Buttons/docs/Checkbox.md
@@ -9,11 +9,12 @@ Associating a label to every radio button is very important for accessibility pu
 <div style={{display: 'flex', flexDirection: 'column'}}>
   <div style={{display: 'flex', marginBottom: 20}}>
     <Checkbox id="checkbox1" isSelected />
-    <label htmlFor="checkbox1" style={{marginLeft: 10}}>Label associated manually</label>
+    <label htmlFor="checkbox1" style={{marginLeft: 10, lineHeight: '22px'}}>Label associated manually</label>
   </div>
   <Checkbox id="checkbox2">Label auto-generated</Checkbox>
 </div>
 ```
+**Important!** If you attach a label to a checkbox manually, make sure you set the line-height and margin-left properties as per the example above.
 
 ### Styling
 You can pass an object to the `style` prop for styling the label, radio button and wrap element using Radium's structure:

--- a/src/components/Buttons/docs/Radio.md
+++ b/src/components/Buttons/docs/Radio.md
@@ -11,11 +11,12 @@ Associating a label to every radio button is very important for accessibility pu
 <div style={{display: 'flex', flexDirection: 'column'}}>
   <div style={{display: 'flex', marginBottom: 20}}>
     <Radio id="radio1" isSelected />
-    <label htmlFor="radio1" style={{marginLeft: 10}}>Label associated manually</label>
+    <label htmlFor="radio1" style={{marginLeft: 10, lineHeight: '22px'}}>Label associated manually</label>
   </div>
   <Radio id="radio2">Label auto-generated</Radio>
 </div>
 ```
+**Important!** If you attach a label to a checkbox manually, make sure you set the line-height and margin-left properties as per the example above.
 
 ### Groups
 To create a radio group where only one button can be selected [see here](#radiogroup).

--- a/src/components/Buttons/docs/Radio.md
+++ b/src/components/Buttons/docs/Radio.md
@@ -16,7 +16,7 @@ Associating a label to every radio button is very important for accessibility pu
   <Radio id="radio2">Label auto-generated</Radio>
 </div>
 ```
-**Important!** If you attach a label to a checkbox manually, make sure you set the line-height and margin-left properties as per the example above.
+**Important!** If you attach a label to a radio button manually, make sure you set the line-height and margin-left properties as per the example above.
 
 ### Groups
 To create a radio group where only one button can be selected [see here](#radiogroup).


### PR DESCRIPTION
Labels will now be center aligned vertically with their associated
checkbox/radio button controls.

Fixes #223 