### PR TITLE
fixes #228 add no padding option to tooltip

### DIFF
--- a/src/components/Tooltip/InnerToolTip.js
+++ b/src/components/Tooltip/InnerToolTip.js
@@ -64,7 +64,8 @@ class InnerToolTip extends PureComponent {
       'medium',
       'large',
     ]),
-    arrowPosition: PropTypes.shape({})
+    arrowPosition: PropTypes.shape({}),
+    noPadding: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -74,9 +75,12 @@ class InnerToolTip extends PureComponent {
 
   get contentStyles() {
     const { size, style, snacksStyle } = this.props
+    const resolvedSize = this.props.noPadding ?
+      {...RESOLVED_SIZE[size], ...{padding: 0}} :
+      RESOLVED_SIZE[size]
     return {
       ...styles.innerContent,
-      ...RESOLVED_SIZE[size],
+      ...resolvedSize,
       ...RESOLVED_COLOR[snacksStyle],
       ...style
     }

--- a/src/components/Tooltip/InnerToolTip.js
+++ b/src/components/Tooltip/InnerToolTip.js
@@ -74,10 +74,10 @@ class InnerToolTip extends PureComponent {
   }
 
   get contentStyles() {
-    const { size, style, snacksStyle } = this.props
-    const resolvedSize = this.props.noPadding ?
+    const { size, style, noPadding, snacksStyle } = this.props
+    const resolvedSize = noPadding ?
       {...RESOLVED_SIZE[size], ...{padding: 0}} :
-      RESOLVED_SIZE[size]
+      {...RESOLVED_SIZE[size]}
     return {
       ...styles.innerContent,
       ...resolvedSize,

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -23,6 +23,7 @@ class Tooltip extends PureComponent {
     onDismiss: PropTypes.func,
     onShow: PropTypes.func,
     isVisible: PropTypes.bool,
+    noPadding: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -78,6 +79,7 @@ class Tooltip extends PureComponent {
       size,
       snacksStyle,
       isVisible,
+      noPadding,
     } = this.props
 
     return (
@@ -92,6 +94,7 @@ class Tooltip extends PureComponent {
           <InnerToolTip
             size={size}
             snacksStyle={snacksStyle}
+            noPadding={noPadding}
           >
             {children}
           </InnerToolTip>

--- a/src/components/Tooltip/__tests__/Tooltip.spec.js
+++ b/src/components/Tooltip/__tests__/Tooltip.spec.js
@@ -6,6 +6,10 @@ import { mount }        from 'enzyme'
 import { spy, stub }    from 'sinon'
 import Tooltip          from '../Tooltip'
 
+console.log = s => {
+  process.stdout.write(s + "\n")
+}
+
 describe('Tooltip', () => {
 
   it('renders Tooltip properly', () => {
@@ -126,4 +130,16 @@ describe('Tooltip', () => {
     expect(tooltip.state().show).toEqual(false)
   })
 
+  it('should have truth prop for noPadding when noPadding is passed in as true', () => {
+
+    const tooltip = mount(
+      <Tooltip
+        target={(<button>TRIGGER</button>)}
+        noPadding={true}
+      >
+      </Tooltip>
+    )
+
+    expect(tooltip.props().noPadding).toEqual(true) 
+  })
 })

--- a/src/components/Tooltip/__tests__/Tooltip.spec.js
+++ b/src/components/Tooltip/__tests__/Tooltip.spec.js
@@ -6,10 +6,6 @@ import { mount }        from 'enzyme'
 import { spy, stub }    from 'sinon'
 import Tooltip          from '../Tooltip'
 
-console.log = s => {
-  process.stdout.write(s + "\n")
-}
-
 describe('Tooltip', () => {
 
   it('renders Tooltip properly', () => {


### PR DESCRIPTION
fixes #228 

This enables us to use the tooltip without having pre-defined padding so we can match what we're building exactly w the design specs.