### PR TITLE
Add typography

### DIFF
--- a/src/components/Typography/Text.js
+++ b/src/components/Typography/Text.js
@@ -17,48 +17,57 @@ const baseStyles = {
   color: colors.GRAY_13
 }
 
+// Matches the Open Sans font weights
+// https://fonts.google.com/specimen/Open+Sans?selection.family=Open+Sans
+const fontWeights = {
+  light: 300,
+  regular: 400,
+  semiBold: 600,
+  bold: 700
+}
+
 const variantStyles = {
   'T.92': {
     fontSize: '92px',
     lineHeight: '138px',
     letterSpacing: '0',
-    fontWeight: 400
+    fontWeight: fontWeights.regular
   },
   'T.82': {
     fontSize: '82px',
     lineHeight: '123px',
     letterSpacing: '0',
-    fontWeight: 400
+    fontWeight: fontWeights.regular
   },
   'T.72': {
     fontSize: '72px',
     lineHeight: '108px',
     letterSpacing: '0',
-    fontWeight: 400
+    fontWeight: fontWeights.regular
   },
   'T.64': {
     fontSize: '64px',
     lineHeight: '96px',
     letterSpacing: '0',
-    fontWeight: 400
+    fontWeight: fontWeights.regular
   },
   'T.58': {
     fontSize: '58px',
     lineHeight: '87px',
     letterSpacing: '0',
-    fontWeight: 400
+    fontWeight: fontWeights.regular
   },
   'T.46': {
     fontSize: '46px',
     lineHeight: '69px',
     letterSpacing: '0',
-    fontWeight: 400
+    fontWeight: fontWeights.regular
   },
   'T.36': {
     fontSize: '36px',
     lineHeight: '54px',
     letterSpacing: '0.03em',
-    fontWeight: 400
+    fontWeight: fontWeights.regular
   },
   'T.28': {
     fontSize: '28px',
@@ -70,37 +79,37 @@ const variantStyles = {
     fontSize: '22px',
     lineHeight: '32px',
     letterSpacing: '0.03em',
-    fontWeight: 400
+    fontWeight: fontWeights.regular
   },
   'T.18': {
     fontSize: '18px',
     lineHeight: '32px',
     letterSpacing: '0.03em',
-    fontWeight: 400
+    fontWeight: fontWeights.regular
   },
   'T.16': {
     fontSize: '16px',
     lineHeight: '24px',
     letterSpacing: '0.03em',
-    fontWeight: 400
+    fontWeight: fontWeights.regular
   },
   'T.14': {
     fontSize: '14px',
     lineHeight: '21px',
     letterSpacing: '0.03em',
-    fontWeight: 400
+    fontWeight: fontWeights.regular
   },
   'T.12': {
     fontSize: '12px',
     lineHeight: '18px',
     letterSpacing: '0.05em',
-    fontWeight: 400
+    fontWeight: fontWeights.regular
   },
   'T.11': {
     fontSize: '11px',
     lineHeight: '16px',
     letterSpacing: '0.05em',
-    fontWeight: 400
+    fontWeight: fontWeights.regular
   }
 }
 
@@ -119,15 +128,6 @@ const htmlTagMapping = {
   'T.14': 'p',
   'T.12': 'p',
   'T.11': 'p'
-}
-
-// Matches the Open Sans font weights
-// https://fonts.google.com/specimen/Open+Sans?selection.family=Open+Sans
-const fontWeights = {
-  light: 300,
-  regular: 400,
-  semiBold: 600,
-  bold: 700
 }
 
 function Text({ variant, style, children, elementType, fontWeight, ...restProps }) {

--- a/src/components/Typography/Text.js
+++ b/src/components/Typography/Text.js
@@ -1,0 +1,168 @@
+import React from 'react'
+import Radium from 'radium'
+import PropTypes from 'prop-types'
+import { colors } from '../../styles'
+
+// Not using `margin` or `padding` shorthand  to avoid any future
+// Radium warnings with combining shorthand/longhand properties.
+const baseStyles = {
+  paddingTop: 0,
+  paddingRight: 0,
+  paddingBottom: 0,
+  paddingLeft: 0,
+  marginTop: 0,
+  marginRight: 0,
+  marginBottom: 0,
+  marginLeft: 0,
+  color: colors.GRAY_13
+}
+
+const variantStyles = {
+  'T.92': {
+    fontSize: '92px',
+    lineHeight: '138px',
+    letterSpacing: '0',
+    fontWeight: 400
+  },
+  'T.82': {
+    fontSize: '82px',
+    lineHeight: '123px',
+    letterSpacing: '0',
+    fontWeight: 400
+  },
+  'T.72': {
+    fontSize: '72px',
+    lineHeight: '108px',
+    letterSpacing: '0',
+    fontWeight: 400
+  },
+  'T.64': {
+    fontSize: '64px',
+    lineHeight: '96px',
+    letterSpacing: '0',
+    fontWeight: 400
+  },
+  'T.58': {
+    fontSize: '58px',
+    lineHeight: '87px',
+    letterSpacing: '0',
+    fontWeight: 400
+  },
+  'T.46': {
+    fontSize: '46px',
+    lineHeight: '69px',
+    letterSpacing: '0',
+    fontWeight: 400
+  },
+  'T.36': {
+    fontSize: '36px',
+    lineHeight: '54px',
+    letterSpacing: '0.03em',
+    fontWeight: 400
+  },
+  'T.28': {
+    fontSize: '28px',
+    lineHeight: '42px',
+    letterSpacing: '0.05em',
+    fontWeight: 700
+  },
+  'T.22': {
+    fontSize: '22px',
+    lineHeight: '32px',
+    letterSpacing: '0.03em',
+    fontWeight: 400
+  },
+  'T.18': {
+    fontSize: '18px',
+    lineHeight: '32px',
+    letterSpacing: '0.03em',
+    fontWeight: 400
+  },
+  'T.16': {
+    fontSize: '16px',
+    lineHeight: '24px',
+    letterSpacing: '0.03em',
+    fontWeight: 400
+  },
+  'T.14': {
+    fontSize: '14px',
+    lineHeight: '21px',
+    letterSpacing: '0.03em',
+    fontWeight: 400
+  },
+  'T.12': {
+    fontSize: '12px',
+    lineHeight: '18px',
+    letterSpacing: '0.05em',
+    fontWeight: 400
+  },
+  'T.11': {
+    fontSize: '11px',
+    lineHeight: '16px',
+    letterSpacing: '0.05em',
+    fontWeight: 400
+  }
+}
+
+const htmlTagMapping = {
+  'T.92': 'h1',
+  'T.82': 'h1',
+  'T.72': 'h1',
+  'T.64': 'h1',
+  'T.58': 'h1',
+  'T.46': 'h1',
+  'T.36': 'h2',
+  'T.28': 'h2',
+  'T.22': 'h2',
+  'T.18': 'p',
+  'T.16': 'p',
+  'T.14': 'p',
+  'T.12': 'p',
+  'T.11': 'p'
+}
+
+// Matches the Open Sans font weights
+// https://fonts.google.com/specimen/Open+Sans?selection.family=Open+Sans
+const fontWeights = {
+  light: 300,
+  regular: 400,
+  semiBold: 600,
+  bold: 700
+}
+
+function Text({ variant, style, children, elementType, fontWeight, ...restProps }) {
+  const ElementType = elementType || htmlTagMapping[variant]
+  const finalStyles = {
+    ...baseStyles,
+    ...variantStyles[variant],
+    ...(fontWeight && { fontWeight: fontWeights[fontWeight] }),
+    ...style
+  }
+
+  return (
+    <ElementType style={finalStyles} {...restProps}>
+      {children}
+    </ElementType>
+  )
+}
+
+Text.propTypes = {
+  /** Typography variant to be used. */
+  variant: PropTypes.oneOf(Object.keys(variantStyles)).isRequired,
+
+  /** Text content to be rendered. */
+  children: PropTypes.node.isRequired,
+
+  /** Overrides the default HTML element type. Each typography variant has a default HTML element (e.g. h1, p),
+   * but this is only a best guess. Always ensure you're using the correct header markup -- element
+   * types with Snacks typography should be used to describe document structure, not visual style. */
+  elementType: PropTypes.string,
+
+  /** Overrides the variant's default font weight. */
+  fontWeight: PropTypes.oneOf(Object.keys(fontWeights)),
+
+  /** Any custom inline styles. Useful for things like gutters and responsive styles. */
+  style: PropTypes.shape({})
+}
+
+export default Radium(Text)

--- a/src/components/Typography/__tests__/Text.spec.js
+++ b/src/components/Typography/__tests__/Text.spec.js
@@ -1,0 +1,60 @@
+import Text from '../Text'
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { StyleRoot } from 'radium'
+
+const getComponent = props => (
+  <StyleRoot>
+    <Text {...props}>Don't talk about snacks</Text>
+  </StyleRoot>
+)
+
+describe('Text', () => {
+  it('renders all typography variants correctly', () => {
+    const variants = [
+      'T.92',
+      'T.82',
+      'T.72',
+      'T.64',
+      'T.58',
+      'T.46',
+      'T.36',
+      'T.28',
+      'T.22',
+      'T.18',
+      'T.16',
+      'T.14',
+      'T.12',
+      'T.11'
+    ]
+
+    variants.forEach(variantName => {
+      const tree = renderer.create(getComponent({ variant: variantName })).toJSON()
+      expect(tree).toMatchSnapshot()
+    })
+  })
+
+  it('applies custom inline styles', () => {
+    const component = getComponent({ variant: 'T.14', style: { marginBottom: '10px' } })
+    const tree = renderer.create(component).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('applies a custom html element type', () => {
+    const component = getComponent({ elementType: 'span', variant: 'T.14' })
+    const tree = renderer.create(component).toJSON()
+
+    // Using `children` since the Radium wrapper will be the root node.
+    expect(tree.children[0].type).toEqual('span')
+  })
+
+  it('applies a custom font weight', () => {
+    const component = getComponent({ variant: 'T.28', fontWeight: 'semiBold' })
+    const tree = renderer
+      .create(component)
+      .toJSON()
+
+    expect(tree.children[0].props.style.fontWeight).toEqual(600)
+  })
+})

--- a/src/components/Typography/__tests__/__snapshots__/Text.spec.js.snap
+++ b/src/components/Typography/__tests__/__snapshots__/Text.spec.js.snap
@@ -1,0 +1,541 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Text applies custom inline styles 1`] = `
+<div
+  data-radium={true}
+>
+  <p
+    data-radium={true}
+    style={
+      Object {
+        "color": "#212121",
+        "fontSize": "14px",
+        "fontWeight": 400,
+        "letterSpacing": "0.03em",
+        "lineHeight": "21px",
+        "marginBottom": "10px",
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+      }
+    }
+  >
+    Don't talk about snacks
+  </p>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Text renders all typography variants correctly 1`] = `
+<div
+  data-radium={true}
+>
+  <h1
+    data-radium={true}
+    style={
+      Object {
+        "color": "#212121",
+        "fontSize": "92px",
+        "fontWeight": 400,
+        "letterSpacing": "0",
+        "lineHeight": "138px",
+        "marginBottom": 0,
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+      }
+    }
+  >
+    Don't talk about snacks
+  </h1>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Text renders all typography variants correctly 2`] = `
+<div
+  data-radium={true}
+>
+  <h1
+    data-radium={true}
+    style={
+      Object {
+        "color": "#212121",
+        "fontSize": "82px",
+        "fontWeight": 400,
+        "letterSpacing": "0",
+        "lineHeight": "123px",
+        "marginBottom": 0,
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+      }
+    }
+  >
+    Don't talk about snacks
+  </h1>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Text renders all typography variants correctly 3`] = `
+<div
+  data-radium={true}
+>
+  <h1
+    data-radium={true}
+    style={
+      Object {
+        "color": "#212121",
+        "fontSize": "72px",
+        "fontWeight": 400,
+        "letterSpacing": "0",
+        "lineHeight": "108px",
+        "marginBottom": 0,
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+      }
+    }
+  >
+    Don't talk about snacks
+  </h1>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Text renders all typography variants correctly 4`] = `
+<div
+  data-radium={true}
+>
+  <h1
+    data-radium={true}
+    style={
+      Object {
+        "color": "#212121",
+        "fontSize": "64px",
+        "fontWeight": 400,
+        "letterSpacing": "0",
+        "lineHeight": "96px",
+        "marginBottom": 0,
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+      }
+    }
+  >
+    Don't talk about snacks
+  </h1>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Text renders all typography variants correctly 5`] = `
+<div
+  data-radium={true}
+>
+  <h1
+    data-radium={true}
+    style={
+      Object {
+        "color": "#212121",
+        "fontSize": "58px",
+        "fontWeight": 400,
+        "letterSpacing": "0",
+        "lineHeight": "87px",
+        "marginBottom": 0,
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+      }
+    }
+  >
+    Don't talk about snacks
+  </h1>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Text renders all typography variants correctly 6`] = `
+<div
+  data-radium={true}
+>
+  <h1
+    data-radium={true}
+    style={
+      Object {
+        "color": "#212121",
+        "fontSize": "46px",
+        "fontWeight": 400,
+        "letterSpacing": "0",
+        "lineHeight": "69px",
+        "marginBottom": 0,
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+      }
+    }
+  >
+    Don't talk about snacks
+  </h1>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Text renders all typography variants correctly 7`] = `
+<div
+  data-radium={true}
+>
+  <h2
+    data-radium={true}
+    style={
+      Object {
+        "color": "#212121",
+        "fontSize": "36px",
+        "fontWeight": 400,
+        "letterSpacing": "0.03em",
+        "lineHeight": "54px",
+        "marginBottom": 0,
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+      }
+    }
+  >
+    Don't talk about snacks
+  </h2>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Text renders all typography variants correctly 8`] = `
+<div
+  data-radium={true}
+>
+  <h2
+    data-radium={true}
+    style={
+      Object {
+        "color": "#212121",
+        "fontSize": "28px",
+        "fontWeight": 700,
+        "letterSpacing": "0.05em",
+        "lineHeight": "42px",
+        "marginBottom": 0,
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+      }
+    }
+  >
+    Don't talk about snacks
+  </h2>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Text renders all typography variants correctly 9`] = `
+<div
+  data-radium={true}
+>
+  <h2
+    data-radium={true}
+    style={
+      Object {
+        "color": "#212121",
+        "fontSize": "22px",
+        "fontWeight": 400,
+        "letterSpacing": "0.03em",
+        "lineHeight": "32px",
+        "marginBottom": 0,
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+      }
+    }
+  >
+    Don't talk about snacks
+  </h2>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Text renders all typography variants correctly 10`] = `
+<div
+  data-radium={true}
+>
+  <p
+    data-radium={true}
+    style={
+      Object {
+        "color": "#212121",
+        "fontSize": "18px",
+        "fontWeight": 400,
+        "letterSpacing": "0.03em",
+        "lineHeight": "32px",
+        "marginBottom": 0,
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+      }
+    }
+  >
+    Don't talk about snacks
+  </p>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Text renders all typography variants correctly 11`] = `
+<div
+  data-radium={true}
+>
+  <p
+    data-radium={true}
+    style={
+      Object {
+        "color": "#212121",
+        "fontSize": "16px",
+        "fontWeight": 400,
+        "letterSpacing": "0.03em",
+        "lineHeight": "24px",
+        "marginBottom": 0,
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+      }
+    }
+  >
+    Don't talk about snacks
+  </p>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Text renders all typography variants correctly 12`] = `
+<div
+  data-radium={true}
+>
+  <p
+    data-radium={true}
+    style={
+      Object {
+        "color": "#212121",
+        "fontSize": "14px",
+        "fontWeight": 400,
+        "letterSpacing": "0.03em",
+        "lineHeight": "21px",
+        "marginBottom": 0,
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+      }
+    }
+  >
+    Don't talk about snacks
+  </p>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Text renders all typography variants correctly 13`] = `
+<div
+  data-radium={true}
+>
+  <p
+    data-radium={true}
+    style={
+      Object {
+        "color": "#212121",
+        "fontSize": "12px",
+        "fontWeight": 400,
+        "letterSpacing": "0.05em",
+        "lineHeight": "18px",
+        "marginBottom": 0,
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+      }
+    }
+  >
+    Don't talk about snacks
+  </p>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Text renders all typography variants correctly 14`] = `
+<div
+  data-radium={true}
+>
+  <p
+    data-radium={true}
+    style={
+      Object {
+        "color": "#212121",
+        "fontSize": "11px",
+        "fontWeight": 400,
+        "letterSpacing": "0.05em",
+        "lineHeight": "16px",
+        "marginBottom": 0,
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+      }
+    }
+  >
+    Don't talk about snacks
+  </p>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;

--- a/src/components/Typography/docs/Text.md
+++ b/src/components/Typography/docs/Text.md
@@ -1,0 +1,119 @@
+Consistent typography and hierarchy is our most useful tool in creating a clear and understandable product for our customers.
+
+Provide a `variant` prop to specify which typography variant to use:
+
+```jsx
+<Text variant="T.14">
+  T.14 (body text)
+</Text>
+```
+
+With an optional `fontWeight`:
+
+```jsx
+<Text variant="T.14" fontWeight="bold">
+  T.14 (bold body text)
+</Text>
+```
+
+With an optional `elementType`. `Text` comes with a default typography variant => HTML element mapping, but you may need to pass a custom element type to ensure your markup is correct:
+
+```jsx
+<Text variant="T.18" elementType="h2">
+  T.18 (title/subtitle text)
+</Text>
+```
+
+Provide an optional style object (will override any existing styles as it's applied last). Use only when other component props are insufficient (e.g. for gutters):
+
+```jsx
+<Text variant="T.14" style={{ marginBottom: 10 }}>
+  T.14 (body text)
+</Text>
+```
+
+```jsx noeditor
+const TypographyTableRow = require('./helpers').TypographyTableRow;
+
+<div style={{marginTop: '24px'}}>
+  <style dangerouslySetInnerHTML={{__html: `
+    .typography-table td {
+      padding: 10px;
+      vertical-align: top;
+    }
+    .typography-table-variant {
+      white-space: nowrap;
+    }
+  `}} />
+  <hr />
+  <div style={{marginTop: '24px'}}>
+    <Text variant="T.28" fontWeight="bold" style={{marginBottom: 16}}>Type Guidelines: Web and Mobile Web</Text>
+    <Text variant="T.16">Guidelines on font treatment along with suggested use cases</Text>
+  </div>
+  <table className="typography-table" style={{width: '100%', marginTop: '24px'}}>
+    <tbody>
+      <TypographyTableRow
+        variant="T.92"
+        usage={['Web: Oversized screen titles', 'Mobile: Calling out metrics and numbers on dashboards or other relevant screens']}
+        example="Snacks"
+      />
+      <TypographyTableRow
+        variant="T.82"
+        usage={['Web: Oversized screen titles', 'Mobile: Calling out metrics and numbers on dashboards or other relevant screens']}
+        example="Snacks"
+      />
+      <TypographyTableRow
+        variant="T.72"
+        usage={['Web: Oversized screen titles', 'Mobile: Calling out metrics and numbers on dashboards or other relevant screens']}
+        example="Snacks"
+      />
+      <TypographyTableRow
+        variant="T.64"
+        usage={['Web: Oversized screen titles', 'Mobile: Calling out metrics and numbers on dashboards or other relevant screens']}
+        example="Snacks"
+      />
+      <TypographyTableRow
+        variant="T.58"
+        usage={['Web: Title size', 'Mobile: Calling out metrics and numbers on dashboards or other relevant screens']}
+        example="Snacks"
+      />
+      <TypographyTableRow
+        variant="T.46"
+        usage={['Web: Top level headers. Ideal as titles on web or subtitles paired with larger sizes']}
+      />
+      <TypographyTableRow
+        variant="T.36"
+        usage={['Web: Standard size for web titles', 'Mobile: Large titles']}
+      />
+      <TypographyTableRow
+        variant="T.28"
+        usage={['Web: Titles for sections, modals, trays, etc.', 'Mobile: Large titles']}
+      />
+      <TypographyTableRow
+        variant="T.22"
+        usage={['Web: Subtitles and section titles', 'Mobile: Large titles']}
+      />
+      <TypographyTableRow
+        variant="T.18"
+        usage={['Web: Subtitles and section titles', 'Mobile: Title. Also used as body size on shopper products']}
+      />
+      <TypographyTableRow
+        variant="T.16"
+        usage={['Web: Body text where 14 is too small', 'Mobile: Title, subtitle, or body text']}
+      />
+      <TypographyTableRow
+        variant="T.14"
+        usage={['Web: Body text, usually good for paragraphs', 'Mobile: Subtitle or body text']}
+      />
+      <TypographyTableRow
+        variant="T.12"
+        usage={['Web: Subtext for de-emphaiszed information', 'Mobile: Body text (e.g. on item cards). More commonly seen on customers side']}
+      />
+      <TypographyTableRow
+        variant="T.11"
+        usage={['Web: DO NOTE USE! Does not meet accessibility standards', 'Mobile: Subtext for de-emphasized information like legal jargon. More commonly seen on customers side']}
+      />
+    </tbody>
+  </table>
+</div>
+```

--- a/src/components/Typography/docs/helpers.js
+++ b/src/components/Typography/docs/helpers.js
@@ -1,0 +1,21 @@
+import React from 'react'
+
+// eslint-disable-next-line
+export const TypographyTableRow = ({ variant, usage, example = "Don't talk about snacks" }) => (
+  <tr>
+    <td className="typography-table-variant">
+      <Text variant={`${variant}`}>{variant}</Text>
+    </td>
+    <td>
+      <Text variant="T.18" fontWeight="bold">Common usage</Text>
+      {usage.map(line => (
+        <Text key={line} variant="T.14">
+          {line}
+        </Text>
+      ))}
+    </td>
+    <td>
+      <Text variant={`${variant}`}>{example}</Text>
+    </td>
+  </tr>
+)

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -76,6 +76,10 @@ module.exports = {
           components: 'src/components/Forms/[A-Z]*.js'
         },
         {
+          name: 'Typography',
+          components: 'src/components/Typography/[A-Z]*.js'
+        },
+        {
           name: 'Grid',
           components: 'src/components/Grid/[A-Z]*.js'
         },


### PR DESCRIPTION
### What
Add typography to snacks. This PR is open as an RFC - I'd love to get everyone's feedback on a few things around the API:

* What component name do we want? I chose `<Text />` to start, but `<Typography />` is also an option.
* What props do we want? Here's the React Material UI typography component for inspiration: https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Typography/Typography.js. On one hand, we could stick with a `style` prop which gives users more flexibility. Or, we could have more specific props like `gutterBottom`, `alignCenter`, etc. I like a `style` prop since it keeps the number of props down, but that might not be true for all.
* Generally open to ideas on how folks might use this, or specific use cases you already have. e.g. should we add specific color props so users can hook into snacks theme colors?
* What html tags should we map to each variant? Check the `htmlTapMapping` object for what I have so far.

### TODO
- [x] Finalize the API
- [x] More specs
- [x] Finish docs (need to add a table column for font size/weight/etc values to match the design system doc)