### PR TITLE
Fix incompatibility with react-hot-loader

### DIFF
--- a/src/components/Menus/Menu.js
+++ b/src/components/Menus/Menu.js
@@ -1,6 +1,7 @@
 import React             from 'react'
 import PropTypes         from 'prop-types'
 import MenuItem          from './MenuItem'
+import getRuntimeType    from '../../utils/getRuntimeType'
 
 const styles = {
   borderRadius: '4px',
@@ -136,7 +137,7 @@ class Menu extends React.Component {
     const menuItemChildren = []
 
     React.Children.map(children, (child) => {
-      if (child.type && child.type === MenuItem) {
+      if (child.type && child.type === getRuntimeType(MenuItem)) {
         menuItemChildren.push(child)
       }
     })
@@ -152,7 +153,7 @@ class Menu extends React.Component {
     return React.Children.map(children, (child) => {
       if (!React.isValidElement(child)) {
         throw 'Passing invalid element to Menu'
-      } else if (child.type && child.type === MenuItem) {
+      } else if (child.type && child.type === getRuntimeType(MenuItem)) {
         const component = React.cloneElement(child, {
           index: index,
           focus: currentTabIndex === index,

--- a/src/utils/getRuntimeType.js
+++ b/src/utils/getRuntimeType.js
@@ -1,0 +1,12 @@
+/*
+ * This resolves an incompatibility with react-hot-loader.
+ * For now, use this function for all element type comparisons.
+ * 
+ * More info: https://github.com/instacart/Snacks/issues/235 
+ */
+import * as React from 'react'
+import _ from 'underscore'
+
+const getRuntimeType = _.memoize((Component) => (<Component/>).type)
+
+export default getRuntimeType


### PR DESCRIPTION
Fixes issue where snacks components which depend on React element type comparison do not function correctly when used from an environment running react-hot-loader.

* Add utility function for runtime element type comparisons
* Refactor Menu component to use new function

Fixes #235 