### PR TITLE
Fix typo to fully resolve RHL issue

### DIFF
--- a/src/utils/getRuntimeType.js
+++ b/src/utils/getRuntimeType.js
@@ -4,7 +4,7 @@
  * 
  * More info: https://github.com/instacart/Snacks/issues/235 
  */
-import * as React from 'react'
+import React from 'react'
 import _ from 'underscore'
 
 const getRuntimeType = _.memoize((Component) => (<Component/>).type)


### PR DESCRIPTION
The first attempt at fixing the react-hot-loader issues on dev machines was unsuccessful. This was due to incorrect import syntax.