### PR TITLE
Underscore round 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "react-transition-group": "^2.2.1",
     "sinon": "^2.3.8",
     "uglifyjs-webpack-plugin": "^1.2.5",
-    "underscore": "^1.8.3",
     "webpack": "^4.12.0",
     "webpack-bundle-analyzer": "^2.13.1",
     "webpack-cli": "^3.0.4"

--- a/src/__tests__/debounce.spec.js
+++ b/src/__tests__/debounce.spec.js
@@ -1,0 +1,55 @@
+import debounce from '../utils/debounce'
+
+describe('debounce', () => {
+  jest.useFakeTimers()
+  let subject = 0
+  const time = 50
+  const afterExecution = time + 1
+  const beforeExecution = time - 1
+  const mockObj = {
+    func: () => {
+      subject = 20
+    }
+  }
+  const debouncedFunc = jest.spyOn(mockObj, 'func')
+  const fastForwardTo = (wait) =>jest.runTimersToTime(wait)
+
+  beforeEach(() => {
+    subject = 0
+  })
+
+  afterEach(() => {
+    jest.runTimersToTime(time)
+    debouncedFunc.mockClear()
+  })
+
+  describe('when evaluted early', () => {
+    beforeEach(() => {
+      debounce(debouncedFunc, time)()
+      fastForwardTo(beforeExecution)
+    })
+
+    it('callback is not called', () => {
+      expect(debouncedFunc).toHaveBeenCalledTimes(0)
+    })
+
+    it('value is not set', () => {
+      expect(subject).toBe(0)
+    })
+  })
+
+  describe('when evaluted after wait', () => {
+    beforeEach(() => {
+      debounce(debouncedFunc, time)()
+      fastForwardTo(afterExecution)
+    })
+
+    it('callback is called', () => {
+      expect(debouncedFunc).toHaveBeenCalledTimes(1)
+    })
+
+    it('sets value', () => {
+      expect(subject).toBe(20)
+    })
+  })
+})

--- a/src/__tests__/isEqual.spec.js
+++ b/src/__tests__/isEqual.spec.js
@@ -91,4 +91,17 @@ describe('isEqual', () => {
       expect(isEqual(first, second)).toBe(false)
     })
   })
+  describe('with circular references', () => {
+    class Circular {
+      constructor() {
+        this.self = this
+      }
+    }
+
+    it('does not blow up', () => {
+      const first = new Circular()
+      const second = new Circular()
+      expect(() => isEqual(first, second)).not.toThrow()
+    })
+  })
 })

--- a/src/__tests__/isEqual.spec.js
+++ b/src/__tests__/isEqual.spec.js
@@ -1,0 +1,94 @@
+import isEqual from '../utils/isEqual'
+
+describe('isEqual', () => {
+  describe('with numbers', () => {
+    it('returns true when equal', () => {
+      expect(isEqual(1, 1)).toBe(true)
+    })
+    it('returns false when not equal', () => {
+      expect(isEqual(1, 2)).toBe(false)
+    })
+  })
+  describe('with arrays', () => {
+    it('returns true when equal', () => {
+      const first = [1,'s', {s: 'f'}]
+      const second = [1,'s', {s: 'f'}]
+      expect(isEqual(first, second)).toBe(true)
+    })
+    it('returns false when not equal', () => {
+      const first = [1,'s', {s: 'f'}]
+      const second = [1,'s', {s: 'r'}]
+      expect(isEqual(first, second)).toBe(false)
+    })
+  })
+  describe('with objects', () => {
+    describe('that are simple', () => {
+      it('returns true when equal', () => {
+        const first = {
+          first: 'key'
+        }
+        const second = {
+          first: 'key'
+        }
+        expect(isEqual(first, second)).toBe(true)
+      })
+      it('returns false when not equal', () => {
+        const first = {
+          first: 'key'
+        }
+        const second = {
+          first: 'keys'
+        }
+        expect(isEqual(first, second)).toBe(false)
+      })
+    })
+    describe('that are complex', () => {
+      it('returns true when equal', () => {
+        const first = {
+          first: 'key',
+          second: [1,'s', {s: 'f'}]
+        }
+        const second = {
+          first: 'key',
+          second: [1,'s', {s: 'f'}]
+        }
+        expect(isEqual(first, second)).toBe(true)
+      })
+      it('returns false when not equal', () => {
+        const first = {
+          first: 'key',
+          second: [1,'s', {s: 'f'}]
+        }
+        const second = {
+          first: 'key',
+          second: [1,'s', {s: 's'}]
+        }
+        expect(isEqual(first, second)).toBe(false)
+      })
+    })
+  })
+  describe('with regExp', () => {
+    it('returns true when equal', () => {
+      const first = /start/
+      const second = /start/
+      expect(isEqual(first, second)).toBe(true)
+    })
+    it('returns false when not equal', () => {
+      const first = /start/
+      const second = /starts/
+      expect(isEqual(first, second)).toBe(false)
+    })
+  })
+  describe('with Date objects', () => {
+    it('returns true when equal', () => {
+      const first = new Date('December 17, 1995 03:24:00')
+      const second = new Date('December 17, 1995 03:24:00')
+      expect(isEqual(first, second)).toBe(true)
+    })
+    it('returns false when not equal', () => {
+      const first = new Date('December 17, 1995 03:24:00')
+      const second = new Date('December 17, 1995 03:24:01')
+      expect(isEqual(first, second)).toBe(false)
+    })
+  })
+})

--- a/src/__tests__/memoize.spec.js
+++ b/src/__tests__/memoize.spec.js
@@ -1,0 +1,64 @@
+import memoize from '../utils/memoize'
+
+const doCallbackFiveTimes = (callback) => {
+  [1,2,3,4,5].forEach(() => callback())
+}
+describe('memoize', () => {
+  describe('returns the correct value', () => {
+    it('when called once', () => {
+      const memoizedFunc = memoize((a, b) => a + b)
+      expect(memoizedFunc(5, 10)).toBe(15)
+    })
+
+    it('when called multiple times', () => {
+      const memoizedFunc = memoize((a, b) => a + b)
+      doCallbackFiveTimes(() => memoizedFunc(5, 100))
+      expect(memoizedFunc(5, 10)).toBe(15)
+    })
+  })
+
+  describe('memoizes arguments to prevent extra calls', () => {
+    let subjectFunctionCalls = 0
+    const subjectFunc = (a, b) => {
+      subjectFunctionCalls += 1
+      return a + b
+    }
+
+    afterEach(() => {
+      subjectFunctionCalls = 0
+    })
+
+    it('counting mechanism works', () => {
+      doCallbackFiveTimes(() => subjectFunc(5, 100))
+      expect(subjectFunctionCalls).toBe(5)
+    })
+
+    it('when implemented once', () => {
+      const memoizedFunc = memoize(subjectFunc)
+      doCallbackFiveTimes(() => memoizedFunc(5, 100))
+      expect(memoizedFunc(5, 100)).toBe(105)
+      expect(subjectFunctionCalls).toBe(1)
+    })
+
+    it('when implemented multiple times', () => {
+      const secondFunc = (a, b) => {
+        subjectFunctionCalls += 1
+        return a + b
+      }
+      const thirdFunc = (a, b) => {
+        subjectFunctionCalls += 1
+        return a + b
+      }
+      const memoizedFunc = memoize(subjectFunc)
+      const secondMemoizedFunc = memoize(secondFunc)
+      const thirdMemoizedFunc = memoize(thirdFunc)
+      doCallbackFiveTimes(() => {
+        memoizedFunc(1, 2)
+        secondMemoizedFunc(3, 4)
+        thirdMemoizedFunc(5, 5)
+      })
+      expect(thirdMemoizedFunc(5, 5)).toBe(10)
+      expect(subjectFunctionCalls).toBe(3)
+    })
+  })
+})

--- a/src/components/Forms/Form.js
+++ b/src/components/Forms/Form.js
@@ -1,6 +1,6 @@
 import React     from 'react'
 import PropTypes from 'prop-types'
-import _         from 'underscore'
+import isEqual from '../../utils/isEqual'
 
 class Form extends React.Component {
   static propTypes = {
@@ -39,7 +39,7 @@ class Form extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.serverErrors && !_.isEqual(this.state.serverErrors, nextProps.serverErrors)) {
+    if (nextProps.serverErrors && !isEqual(this.state.serverErrors, nextProps.serverErrors)) {
       this.setState({serverErrors: nextProps.serverErrors}, () => {
         this.setErrorsOnFormComponents(this.state.serverErrors)
       })

--- a/src/components/ScrollTrack/ScrollTrack.js
+++ b/src/components/ScrollTrack/ScrollTrack.js
@@ -4,11 +4,12 @@ import ScrollTrackPropTypes from './ScrollTrackPropTypes'
 
 import React, { Component } from 'react'
 import { isNodeEnv } from '../../utils/detectFeature'
+import debounce from '../../utils/debounce'
+import isEqual from '../../utils/isEqual'
 import CircleButton  from '../Buttons/CircleButton'
 import Icon          from '../Icon/Icon'
 import Radium        from 'radium'
 import PropTypes     from 'prop-types'
-import _             from 'underscore'
 
 
 const noOp = () => {} // eslint-disable-line no-empty-function
@@ -99,7 +100,7 @@ class ScrollTrack extends Component {
   }
 
   componentDidMount() {
-    this.debouncdComputeSlideAttributes = _.debounce(this.computeSlideAttributes, 200)
+    this.debouncdComputeSlideAttributes = debounce(this.computeSlideAttributes, 200)
     this.computeSlideAttributes()
 
     if (!isNodeEnv()) {
@@ -119,7 +120,7 @@ class ScrollTrack extends Component {
     const prevChildren = prevProps.children || []
     const newChildren = this.props.children || []
 
-    if (!_.isEqual(prevChildren, newChildren)) {
+    if (!isEqual(prevChildren, newChildren)) {
       this.computeSlideAttributes()
     }
   }

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -1,6 +1,6 @@
 import tinycolor from 'tinycolor2'
-import _ from 'underscore'
+import memoize from './memoize'
 
-export const darken = _.memoize((baseColor, amount) => {
+export const darken = memoize((baseColor, amount) => {
   return tinycolor(baseColor).darken(amount).toHexString()
 })

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,0 +1,7 @@
+export default (func, wait) => {
+  let timeout
+  return (...args) => {
+    clearTimeout(timeout)
+    timeout = setTimeout(() => func.apply(this, args), wait)
+  }
+}

--- a/src/utils/detectFeature.js
+++ b/src/utils/detectFeature.js
@@ -1,6 +1,6 @@
-import _ from 'underscore'
+import memoize from './memoize'
 
-export const supportsCSSGrid = _.memoize(() => {
+export const supportsCSSGrid = memoize(() => {
   if (isNodeEnv() || isTestEnv()) { return true }
 
   const elm = document.createElement('div')

--- a/src/utils/getRuntimeType.js
+++ b/src/utils/getRuntimeType.js
@@ -1,12 +1,12 @@
 /*
  * This resolves an incompatibility with react-hot-loader.
  * For now, use this function for all element type comparisons.
- * 
- * More info: https://github.com/instacart/Snacks/issues/235 
+ *
+ * More info: https://github.com/instacart/Snacks/issues/235
  */
 import React from 'react'
-import _ from 'underscore'
+import memoize from './memoize'
 
-const getRuntimeType = _.memoize((Component) => (<Component/>).type)
+const getRuntimeType = memoize((Component) => (<Component/>).type)
 
 export default getRuntimeType

--- a/src/utils/isEqual.js
+++ b/src/utils/isEqual.js
@@ -1,0 +1,55 @@
+const isArray = Array.isArray
+const keyList = Object.keys
+const hasProp = Object.prototype.hasOwnProperty
+
+const equal = (a, b) => {
+  if (a === b) return true
+
+  if (a && b && typeof a == 'object' && typeof b == 'object') {
+    const arrA = isArray(a)
+    const arrB = isArray(b)
+    let i
+    let length
+    let key
+
+    if (arrA && arrB) {
+      length = a.length
+      if (length != b.length) return false
+      for (i = length; i-- !== 0;)
+        if (!equal(a[i], b[i])) return false
+      return true
+    }
+
+    if (arrA != arrB) return false
+
+    const dateA = a instanceof Date
+    const dateB = b instanceof Date
+    if (dateA != dateB) return false
+    if (dateA && dateB) return a.getTime() == b.getTime()
+
+    const regexpA = a instanceof RegExp
+    const regexpB = b instanceof RegExp
+    if (regexpA != regexpB) return false
+    if (regexpA && regexpB) return a.toString() == b.toString()
+
+    const keys = keyList(a)
+    length = keys.length
+
+    if (length !== keyList(b).length)
+      return false
+
+    for (i = length; i-- !== 0;)
+      if (!hasProp.call(b, keys[i])) return false
+
+    for (i = length; i-- !== 0;) {
+      key = keys[i]
+      if (!equal(a[key], b[key])) return false
+    }
+
+    return true
+  }
+
+  return a!==a && b!==b
+}
+
+export default equal

--- a/src/utils/memoize.js
+++ b/src/utils/memoize.js
@@ -1,0 +1,15 @@
+export default (func) => {
+  const memoizedFunc = function () {
+    let result
+    const key = JSON.stringify(arguments)
+    if (memoizedFunc.cache[key] !== undefined) {
+      result = memoizedFunc.cache[key]
+    } else {
+      result = func.apply(null, arguments)
+      memoizedFunc.cache[key] = result
+    }
+    return result
+  }
+  memoizedFunc.cache = {}
+  return memoizedFunc
+}


### PR DESCRIPTION
My implementation of `isEqual` crashed on circular references. I took the underscore `isEqual` implementation and just refactored out underscore helpers for identical functionality. I also added a spec (and verified that my previous implementation blew up in the spec) to verify that the issue was resolved.