### PR TITLE
Adding support for <Table/>

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -90,6 +90,7 @@ If you're creating a new component, that component must be snapshot tested and f
 New components must:
 * have comprehensive tests
 * have comprehensive documentation
+* add component to `styleguide.config.js`
 * follow our code conventions
 * be reviewed and approved
 

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -1,0 +1,108 @@
+import React      from 'react'
+import PropTypes  from 'prop-types'
+import Radium     from 'radium'
+
+const styles = {
+  table: {
+    borderCollapse: 'collapse',
+    borderRadius: '4px',
+    borderSpacing: 0,
+    boxShadow: '0 1px 2px #aaa',
+    overflow: 'hidden',
+    width: '100%',
+  },
+
+  cell: {
+    background: '#fff',
+    fontSize: '14px',
+    fontWeight: 400,
+    height: '48px',
+    lineHeight: '48px',
+    padding: '0 16px',
+    textAlign: 'left',
+    whiteSpace: 'nowrap',
+  },
+
+  cellAlt: {
+    background: '#f7f7f7'
+  }
+
+  cellClickable: {
+    background: '#feffe8',
+    cursor: 'pointer'
+  }
+}
+
+const Table = props => {
+  const { withHeader = true, definition, onRowClick, data } = this.props
+  const haveRowClick = !!onRowClick
+
+  return (
+    <table style={styles.table}>
+      {!withHeader ? null : (
+        <thead>
+          <tr>
+            {definition.map((def, index) => (
+              <th key={index} style={styles.cell}>
+                {def.header !== undefined ? def.header : def.attribute}
+              </th>
+            ))}
+          </tr>
+        </thead>
+      )}
+
+      <tbody>
+        {data.map((row, index) => (
+          <tr
+            key={index}
+            onClick={!onRowClick ? null : () => {
+              onRowClick(row)
+            }}
+          >
+            {definition.map((def, cellIndex) => {
+              const cellStyles = [styles.cell]
+              if (index % 2 === 0) {
+                cellStyles.push(styles.cellAlt)
+              }
+              if (haveRowClick) {
+                cellStyles.push(styles.cellClickable)
+              }
+              
+              return (
+                <td key={cellIndex} style={Object.assign.apply(null, [{}, ...cellStyles])}>
+                  {def.cellRender ? def.cellRender(row[def.attribute], index, row) : row[def.attribute]}
+                </td>
+              )
+            })}
+          </tr>
+        ))}
+      </tbody>
+
+      <style jsx>{styles}</style>
+    </table>
+  )
+}
+
+Table.propTypes = {
+  data: PropTypes
+    .arrayOf(PropTypes.object)
+    .isRequired,
+
+  definition: (props, propName) => {
+    const definition = props[propName]
+
+    if (!Array.isArray(definition)) {
+      return new Error('Table required definition prop must be an Array')
+    }
+
+    for (const cell of definition) {
+      if (cell.attribute === undefined) {
+        return new Error('All Table definition object must have an .attribute')
+      }
+    }
+  },
+
+  withHeader: PropTypes.bool,
+}
+
+export default Radium(Table)

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -2,6 +2,7 @@ import React               from 'react'
 import PropTypes           from 'prop-types'
 import Radium              from 'radium'
 import { spacing, colors } from '../../styles'
+import responsive          from '../../styles/responsive'
 
 const styles = {
   table: {
@@ -22,12 +23,25 @@ const styles = {
     padding: `0 ${spacing.SM}px`,
     textAlign: 'left',
     whiteSpace: 'nowrap',
+
+    [responsive.md]: {
+      height: spacing.LG,
+      lineHeight: `${spacing.LG}px`,
+      padding: `0 ${spacing.XS}px`,
+    },
+
+    [responsive.sm]: {
+      fontSize: '12px',
+      height: spacing.MD,
+      lineHeight: `${spacing.MD}px`,
+    }
   },
 
   cellAlt: {
     background: colors.GRAY_97,
   }
 }
+styles.cell[responsive.xs] = styles.cell[responsive.sm]
 
 const Table = props => {
   const { withHeader, definition, data } = props

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -26,18 +26,11 @@ const styles = {
 
   cellAlt: {
     background: colors.GRAY_97,
-  },
-
-  clickable: {
-    cursor: 'pointer',
-    // ':hover': {
-    //   background: '#FEFFE8',
-    // }
   }
 }
 
 const Table = props => {
-  const { withHeader, definition, onRowClick, data } = props
+  const { withHeader, definition, data } = props
 
   return (
     <table style={styles.table}>
@@ -56,34 +49,18 @@ const Table = props => {
       <tbody>
         {data.map((row, index) => (
           <tr key={index}>
-            {definition.map((def, cellIndex) => {
-              const cellStyles = [styles.cell]
-              if (index % 2 === 0) {
-                cellStyles.push(styles.cellAlt)
-              }
-
-              const clickHandler = def.onClick || onRowClick
-              if (clickHandler) {
-                cellStyles.push(styles.clickable)
-              }
-
-              return (
-                <td
-                  key={cellIndex}
-                  style={cellStyles}
-                  onClick={!clickHandler ? null : () => {
-                    clickHandler(row)
-                  }}
-                  onKeyPress={event => {
-                    if (event.code === 13 && clickHandler) {
-                      clickHandler(row)
-                    }
-                  }}
-                >
-                  {def.cellRender ? def.cellRender(row[def.attribute], index, row) : row[def.attribute]}
-                </td>
-              )
-            })}
+            {definition.map((def, cellIndex) => (
+              <td
+                key={cellIndex}
+                style={[
+                  styles.cell,
+                  index % 2 === 0 && styles.cellAlt
+                ]}
+                {...Object.assign({}, def, { header: null, attribute: null, cellRender: null })}
+              >
+                {def.cellRender ? def.cellRender(row[def.attribute], index, row) : row[def.attribute]}
+              </td>
+            ))}
           </tr>
         ))}
       </tbody>
@@ -111,8 +88,6 @@ Table.propTypes = {
   },
 
   withHeader: PropTypes.bool,
-
-  onRowClick: PropTypes.func
 }
 
 Table.defaultProps = {

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -28,7 +28,6 @@ const styles = {
   },
 
   cellClickable: {
-    background: '#feffe8',
     cursor: 'pointer'
   }
 }

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -25,7 +25,7 @@ const styles = {
 
   cellAlt: {
     background: '#f7f7f7'
-  }
+  },
 
   cellClickable: {
     background: '#feffe8',
@@ -34,7 +34,7 @@ const styles = {
 }
 
 const Table = props => {
-  const { withHeader = true, definition, onRowClick, data } = this.props
+  const { withHeader = true, definition, onRowClick, data } = props
   const haveRowClick = !!onRowClick
 
   return (
@@ -60,7 +60,7 @@ const Table = props => {
             }}
           >
             {definition.map((def, cellIndex) => {
-              const cellStyles = [styles.cell]
+              const cellStyles = [{}, styles.cell]
               if (index % 2 === 0) {
                 cellStyles.push(styles.cellAlt)
               }
@@ -69,7 +69,7 @@ const Table = props => {
               }
               
               return (
-                <td key={cellIndex} style={Object.assign.apply(null, [{}, ...cellStyles])}>
+                <td key={cellIndex} style={Object.assign.apply(null, cellStyles)}>
                   {def.cellRender ? def.cellRender(row[def.attribute], index, row) : row[def.attribute]}
                 </td>
               )
@@ -77,8 +77,6 @@ const Table = props => {
           </tr>
         ))}
       </tbody>
-
-      <style jsx>{styles}</style>
     </table>
   )
 }

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -24,88 +24,95 @@ const styles = {
   },
 
   cellAlt: {
-    background: '#f7f7f7'
+    background: '#f7f7f7',
   },
 
-  cellClickable: {
+  clickable: {
     cursor: 'pointer',
-
-    ':hover': {
-      background: '#feffe8'
-    }
+    // ':hover': {
+    //   background: '#feffe8',
+    // }
   }
 }
 
-const Table = props => {
-  const { withHeader = true, definition, onRowClick, data } = props
+@Radium
+class Table extends React.PureComponent {
+  static propTypes = {
+    data: PropTypes
+      .arrayOf(PropTypes.object)
+      .isRequired,
 
-  return (
-    <table style={styles.table}>
-      {!withHeader ? null : (
-        <thead>
-          <tr>
-            {definition.map((def, index) => (
-              <th key={index} style={styles.cell}>
-                {def.header !== undefined ? def.header : def.attribute}
-              </th>
-            ))}
-          </tr>
-        </thead>
-      )}
+    definition: (props, propName) => {
+      const definition = props[propName]
 
-      <tbody>
-        {data.map((row, index) => (
-          <tr key={index}>
-            {definition.map((def, cellIndex) => {
-              const cellStyles = [{}, styles.cell]
-              if (index % 2 === 0) {
-                cellStyles.push(styles.cellAlt)
-              }
-
-              const clickHandler = def.onClick || onRowClick
-              if (clickHandler) {
-                cellStyles.push(styles.cellClickable)
-              }
-              
-              return (
-                <td
-                  key={cellIndex}
-                  style={Object.assign.apply(null, cellStyles)}
-                  onClick={!clickHandler ? null : () => {
-                    clickHandler(row)
-                  }}
-                >
-                  {def.cellRender ? def.cellRender(row[def.attribute], index, row) : row[def.attribute]}
-                </td>
-              )
-            })}
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  )
-}
-
-Table.propTypes = {
-  data: PropTypes
-    .arrayOf(PropTypes.object)
-    .isRequired,
-
-  definition: (props, propName) => {
-    const definition = props[propName]
-
-    if (!Array.isArray(definition)) {
-      return new Error('Table required definition prop must be an Array')
-    }
-
-    for (const cell of definition) {
-      if (cell.attribute === undefined) {
-        return new Error('All Table definition object must have an .attribute')
+      if (!Array.isArray(definition)) {
+        return new Error('Table required definition prop must be an Array')
       }
-    }
-  },
 
-  withHeader: PropTypes.bool,
+      for (const cell of definition) {
+        if (cell.attribute === undefined) {
+          return new Error('All Table definition object must have an .attribute')
+        }
+      }
+    },
+
+    withHeader: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    withHeader: true,
+  }
+
+  render() {
+
+    const { withHeader, definition, onRowClick, data } = this.props
+
+    return (
+      <table style={styles.table}>
+        {!withHeader ? null : (
+          <thead>
+            <tr>
+              {definition.map((def, index) => (
+                <th key={index} style={styles.cell}>
+                  {def.header !== undefined ? def.header : def.attribute}
+                </th>
+              ))}
+            </tr>
+          </thead>
+        )}
+
+        <tbody>
+          {data.map((row, index) => (
+            <tr key={index}>
+              {definition.map((def, cellIndex) => {
+                const cellStyles = [styles.cell]
+                if (index % 2 === 0) {
+                  cellStyles.push(styles.cellAlt)
+                }
+
+                const clickHandler = def.onClick || onRowClick
+                if (clickHandler) {
+                  cellStyles.push(styles.clickable)
+                }
+
+                return (
+                  <td
+                    key={cellIndex}
+                    style={[...cellStyles]}
+                    onClick={!clickHandler ? null : () => {
+                      clickHandler(row)
+                    }}
+                  >
+                    {def.cellRender ? def.cellRender(row[def.attribute], index, row) : row[def.attribute]}
+                  </td>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )
+  }
 }
 
-export default Radium(Table)
+export default Table

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -74,6 +74,11 @@ const Table = props => {
                   onClick={!clickHandler ? null : () => {
                     clickHandler(row)
                   }}
+                  onKeyPress={event => {
+                    if (event.code === 13 && clickHandler) {
+                      clickHandler(row)
+                    }
+                  }}
                 >
                   {def.cellRender ? def.cellRender(row[def.attribute], index, row) : row[def.attribute]}
                 </td>
@@ -106,6 +111,8 @@ Table.propTypes = {
   },
 
   withHeader: PropTypes.bool,
+
+  onRowClick: PropTypes.func
 }
 
 Table.defaultProps = {

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -68,27 +68,24 @@ const Table = props => {
   )
 }
 
-function definitionType(props, propName) {
-  const definition = props[propName]
-
-  if (!Array.isArray(definition)) {
-    return new Error('Table required definition prop must be an Array')
-  }
-
-  for (const cell of definition) {
-    if (cell.attribute === undefined) {
-      return new Error('All Table definition object must have an .attribute')
-    }
-  }
-}
-definitionType.isRequired = true
-
 Table.propTypes = {
   data: PropTypes
     .arrayOf(PropTypes.object)
     .isRequired,
 
-  definition: definitionType,
+  definition: (props, propName) => {
+    const definition = props[propName]
+
+    if (!Array.isArray(definition)) {
+      throw new Error('Table required definition prop must be an Array')
+    }
+
+    for (const cell of definition) {
+      if (cell.attribute === undefined) {
+        throw new Error('All Table definition object must have an .attribute')
+      }
+    }
+  },
 
   withHeader: PropTypes.bool,
 }

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -28,13 +28,16 @@ const styles = {
   },
 
   cellClickable: {
-    cursor: 'pointer'
+    cursor: 'pointer',
+
+    ':hover': {
+      background: '#feffe8'
+    }
   }
 }
 
 const Table = props => {
   const { withHeader = true, definition, onRowClick, data } = props
-  const haveRowClick = !!onRowClick
 
   return (
     <table style={styles.table}>
@@ -52,23 +55,26 @@ const Table = props => {
 
       <tbody>
         {data.map((row, index) => (
-          <tr
-            key={index}
-            onClick={!onRowClick ? null : () => {
-              onRowClick(row)
-            }}
-          >
+          <tr key={index}>
             {definition.map((def, cellIndex) => {
               const cellStyles = [{}, styles.cell]
               if (index % 2 === 0) {
                 cellStyles.push(styles.cellAlt)
               }
-              if (haveRowClick) {
+
+              const clickHandler = def.onClick || onRowClick
+              if (clickHandler) {
                 cellStyles.push(styles.cellClickable)
               }
               
               return (
-                <td key={cellIndex} style={Object.assign.apply(null, cellStyles)}>
+                <td
+                  key={cellIndex}
+                  style={Object.assign.apply(null, cellStyles)}
+                  onClick={!clickHandler ? null : () => {
+                    clickHandler(row)
+                  }}
+                >
                   {def.cellRender ? def.cellRender(row[def.attribute], index, row) : row[def.attribute]}
                 </td>
               )

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -68,24 +68,27 @@ const Table = props => {
   )
 }
 
+function definitionType(props, propName) {
+  const definition = props[propName]
+
+  if (!Array.isArray(definition)) {
+    return new Error('Table required definition prop must be an Array')
+  }
+
+  for (const cell of definition) {
+    if (cell.attribute === undefined) {
+      return new Error('All Table definition object must have an .attribute')
+    }
+  }
+}
+definitionType.isRequired = true
+
 Table.propTypes = {
   data: PropTypes
     .arrayOf(PropTypes.object)
     .isRequired,
 
-  definition: (props, propName) => {
-    const definition = props[propName]
-
-    if (!Array.isArray(definition)) {
-      return new Error('Table required definition prop must be an Array')
-    }
-
-    for (const cell of definition) {
-      if (cell.attribute === undefined) {
-        return new Error('All Table definition object must have an .attribute')
-      }
-    }
-  },
+  definition: definitionType,
 
   withHeader: PropTypes.bool,
 }

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -1,118 +1,115 @@
-import React      from 'react'
-import PropTypes  from 'prop-types'
-import Radium     from 'radium'
+import React               from 'react'
+import PropTypes           from 'prop-types'
+import Radium              from 'radium'
+import { spacing, colors } from '../../styles'
 
 const styles = {
   table: {
     borderCollapse: 'collapse',
     borderRadius: '4px',
     borderSpacing: 0,
-    boxShadow: '0 1px 2px #aaa',
+    boxShadow: '0 1px 2px #AAA',
     overflow: 'hidden',
     width: '100%',
   },
 
   cell: {
-    background: '#fff',
+    background: colors.WHITE,
     fontSize: '14px',
     fontWeight: 400,
-    height: '48px',
-    lineHeight: '48px',
-    padding: '0 16px',
+    height: spacing.XL,
+    lineHeight: `${spacing.XL}px`,
+    padding: `0 ${spacing.SM}px`,
     textAlign: 'left',
     whiteSpace: 'nowrap',
   },
 
   cellAlt: {
-    background: '#f7f7f7',
+    background: colors.GRAY_97,
   },
 
   clickable: {
     cursor: 'pointer',
     // ':hover': {
-    //   background: '#feffe8',
+    //   background: '#FEFFE8',
     // }
   }
 }
 
-@Radium
-class Table extends React.PureComponent {
-  static propTypes = {
-    data: PropTypes
-      .arrayOf(PropTypes.object)
-      .isRequired,
+const Table = props => {
+  const { withHeader, definition, onRowClick, data } = props
 
-    definition: (props, propName) => {
-      const definition = props[propName]
+  return (
+    <table style={styles.table}>
+      {!withHeader ? null : (
+        <thead>
+          <tr>
+            {definition.map((def, index) => (
+              <th key={index} style={styles.cell}>
+                {def.header !== undefined ? def.header : def.attribute}
+              </th>
+            ))}
+          </tr>
+        </thead>
+      )}
 
-      if (!Array.isArray(definition)) {
-        return new Error('Table required definition prop must be an Array')
-      }
+      <tbody>
+        {data.map((row, index) => (
+          <tr key={index}>
+            {definition.map((def, cellIndex) => {
+              const cellStyles = [styles.cell]
+              if (index % 2 === 0) {
+                cellStyles.push(styles.cellAlt)
+              }
 
-      for (const cell of definition) {
-        if (cell.attribute === undefined) {
-          return new Error('All Table definition object must have an .attribute')
-        }
-      }
-    },
+              const clickHandler = def.onClick || onRowClick
+              if (clickHandler) {
+                cellStyles.push(styles.clickable)
+              }
 
-    withHeader: PropTypes.bool,
-  }
-
-  static defaultProps = {
-    withHeader: true,
-  }
-
-  render() {
-
-    const { withHeader, definition, onRowClick, data } = this.props
-
-    return (
-      <table style={styles.table}>
-        {!withHeader ? null : (
-          <thead>
-            <tr>
-              {definition.map((def, index) => (
-                <th key={index} style={styles.cell}>
-                  {def.header !== undefined ? def.header : def.attribute}
-                </th>
-              ))}
-            </tr>
-          </thead>
-        )}
-
-        <tbody>
-          {data.map((row, index) => (
-            <tr key={index}>
-              {definition.map((def, cellIndex) => {
-                const cellStyles = [styles.cell]
-                if (index % 2 === 0) {
-                  cellStyles.push(styles.cellAlt)
-                }
-
-                const clickHandler = def.onClick || onRowClick
-                if (clickHandler) {
-                  cellStyles.push(styles.clickable)
-                }
-
-                return (
-                  <td
-                    key={cellIndex}
-                    style={cellStyles}
-                    onClick={!clickHandler ? null : () => {
-                      clickHandler(row)
-                    }}
-                  >
-                    {def.cellRender ? def.cellRender(row[def.attribute], index, row) : row[def.attribute]}
-                  </td>
-                )
-              })}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    )
-  }
+              return (
+                <td
+                  key={cellIndex}
+                  style={cellStyles}
+                  onClick={!clickHandler ? null : () => {
+                    clickHandler(row)
+                  }}
+                >
+                  {def.cellRender ? def.cellRender(row[def.attribute], index, row) : row[def.attribute]}
+                </td>
+              )
+            })}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
 }
 
-export default Table
+Table.propTypes = {
+  data: PropTypes
+    .arrayOf(PropTypes.object)
+    .isRequired,
+
+  definition: (props, propName) => {
+    const definition = props[propName]
+
+    if (!Array.isArray(definition)) {
+      return new Error('Table required definition prop must be an Array')
+    }
+
+    for (const cell of definition) {
+      if (cell.attribute === undefined) {
+        return new Error('All Table definition object must have an .attribute')
+      }
+    }
+  },
+
+  withHeader: PropTypes.bool,
+}
+
+Table.defaultProps = {
+  withHeader: true,
+}
+
+export default Radium(Table)

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -98,7 +98,7 @@ class Table extends React.PureComponent {
                 return (
                   <td
                     key={cellIndex}
-                    style={[...cellStyles]}
+                    style={cellStyles}
                     onClick={!clickHandler ? null : () => {
                       clickHandler(row)
                     }}

--- a/src/components/Table/__tests__/Table.spec.js
+++ b/src/components/Table/__tests__/Table.spec.js
@@ -1,0 +1,97 @@
+import React         from 'react'
+import renderer      from 'react-test-renderer'
+import { StyleRoot } from 'radium'
+import { mount }     from 'enzyme'
+import { spy }       from 'sinon'
+import Table         from '../Table'
+
+it('renders Table with minimal definition correctly', () => {
+  const tree = renderer.create(
+    <StyleRoot>
+      <div>
+        <Table
+          data={[
+            { name: 'Apple', type: 'fruit' },
+            { name: 'Carrot', type: 'vegetable' },
+            { name: 'Lemon', type: 'fruit' },
+            { name: 'Avocado', type: 'vegetable' }
+          ]}
+          definition={[
+            { attribute: 'name' },
+            { attribute: 'type' }
+          ]}
+        />
+      </div>
+    </StyleRoot>
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders Table with definition headers correctly', () => {
+  const tree = renderer.create(
+    <StyleRoot>
+      <div>
+        <Table
+          data={[
+            { name: 'Apple', type: 'fruit', qty: 3 },
+            { name: 'Carrot', type: 'vegetable', qty: 99 },
+            { name: 'Lemon', type: 'fruit', qty: 12 },
+            { name: 'Avocado', type: 'vegetable', qty: 0 }
+          ]}
+          definition={[
+            { header: 'Type', attribute: 'type' },
+            { header: 'Name', attribute: 'name' },
+            { header: 'Quantity', attribute: 'qty' }
+          ]}
+        />
+      </div>
+    </StyleRoot>
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders Table with cellRender methods correctly', () => {
+  const tree = renderer.create(
+    <StyleRoot>
+      <div>
+        <Table
+          data={[
+            { name: 'Apple', type: 'fruit', qty: 3 },
+            { name: 'Carrot', type: 'vegetable', qty: 99 },
+            { name: 'Lemon', type: 'fruit', qty: 12 },
+            { name: 'Avocado', type: 'vegetable', qty: 0 }
+          ]}
+          definition={[
+            { header: 'Name', attribute: 'name', cellRender: name => name.toLowerCase() },
+            { header: 'Type', attribute: 'type', cellRender: type => type.charAt(0) },
+            { header: 'Quantity', attribute: 'qty', cellRender: (qty, index, row) => `[${index}]: ${qty} ${row.name}s left` }
+          ]}
+        />
+      </div>
+    </StyleRoot>
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders Table without header if specified', () => {
+  const tree = renderer.create(
+    <StyleRoot>
+      <div>
+        <Table
+          data={[
+            { name: 'Apple', type: 'fruit' },
+            { name: 'Carrot', type: 'vegetable' },
+            { name: 'Lemon', type: 'fruit' },
+            { name: 'Avocado', type: 'vegetable' }
+          ]}
+          definition={[
+            { attribute: 'name' },
+            { attribute: 'type' }
+          ]}
+          withHeader={false}
+        />
+      </div>
+    </StyleRoot>
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/Table/__tests__/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__tests__/__snapshots__/Table.spec.js.snap
@@ -1,0 +1,1161 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders Table with cellRender methods correctly 1`] = `
+<div
+  data-radium={true}
+>
+  <div>
+    <table
+      data-radium={true}
+      style={
+        Object {
+          "borderCollapse": "collapse",
+          "borderRadius": "4px",
+          "borderSpacing": 0,
+          "boxShadow": "0 1px 2px #AAA",
+          "overflow": "hidden",
+          "width": "100%",
+        }
+      }
+    >
+      <thead
+        data-radium={true}
+      >
+        <tr
+          data-radium={true}
+        >
+          <th
+            data-radium={true}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Name
+          </th>
+          <th
+            data-radium={true}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Type
+          </th>
+          <th
+            data-radium={true}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Quantity
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        data-radium={true}
+      >
+        <tr
+          data-radium={true}
+        >
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            apple
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            f
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            [0]: 3 Apples left
+          </td>
+        </tr>
+        <tr
+          data-radium={true}
+        >
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            carrot
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            v
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            [1]: 99 Carrots left
+          </td>
+        </tr>
+        <tr
+          data-radium={true}
+        >
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            lemon
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            f
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            [2]: 12 Lemons left
+          </td>
+        </tr>
+        <tr
+          data-radium={true}
+        >
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            avocado
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            v
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            [3]: 0 Avocados left
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`renders Table with definition headers correctly 1`] = `
+<div
+  data-radium={true}
+>
+  <div>
+    <table
+      data-radium={true}
+      style={
+        Object {
+          "borderCollapse": "collapse",
+          "borderRadius": "4px",
+          "borderSpacing": 0,
+          "boxShadow": "0 1px 2px #AAA",
+          "overflow": "hidden",
+          "width": "100%",
+        }
+      }
+    >
+      <thead
+        data-radium={true}
+      >
+        <tr
+          data-radium={true}
+        >
+          <th
+            data-radium={true}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Type
+          </th>
+          <th
+            data-radium={true}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Name
+          </th>
+          <th
+            data-radium={true}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Quantity
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        data-radium={true}
+      >
+        <tr
+          data-radium={true}
+        >
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            fruit
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Apple
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          data-radium={true}
+        >
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            vegetable
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Carrot
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            99
+          </td>
+        </tr>
+        <tr
+          data-radium={true}
+        >
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            fruit
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Lemon
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            12
+          </td>
+        </tr>
+        <tr
+          data-radium={true}
+        >
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            vegetable
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Avocado
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            0
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`renders Table with minimal definition correctly 1`] = `
+<div
+  data-radium={true}
+>
+  <div>
+    <table
+      data-radium={true}
+      style={
+        Object {
+          "borderCollapse": "collapse",
+          "borderRadius": "4px",
+          "borderSpacing": 0,
+          "boxShadow": "0 1px 2px #AAA",
+          "overflow": "hidden",
+          "width": "100%",
+        }
+      }
+    >
+      <thead
+        data-radium={true}
+      >
+        <tr
+          data-radium={true}
+        >
+          <th
+            data-radium={true}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            name
+          </th>
+          <th
+            data-radium={true}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            type
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        data-radium={true}
+      >
+        <tr
+          data-radium={true}
+        >
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Apple
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            fruit
+          </td>
+        </tr>
+        <tr
+          data-radium={true}
+        >
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Carrot
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            vegetable
+          </td>
+        </tr>
+        <tr
+          data-radium={true}
+        >
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Lemon
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            fruit
+          </td>
+        </tr>
+        <tr
+          data-radium={true}
+        >
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Avocado
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            vegetable
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`renders Table without header if specified 1`] = `
+<div
+  data-radium={true}
+>
+  <div>
+    <table
+      data-radium={true}
+      style={
+        Object {
+          "borderCollapse": "collapse",
+          "borderRadius": "4px",
+          "borderSpacing": 0,
+          "boxShadow": "0 1px 2px #AAA",
+          "overflow": "hidden",
+          "width": "100%",
+        }
+      }
+    >
+      <tbody
+        data-radium={true}
+      >
+        <tr
+          data-radium={true}
+        >
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Apple
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            fruit
+          </td>
+        </tr>
+        <tr
+          data-radium={true}
+        >
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Carrot
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            vegetable
+          </td>
+        </tr>
+        <tr
+          data-radium={true}
+        >
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Lemon
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#F7F7F7",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            fruit
+          </td>
+        </tr>
+        <tr
+          data-radium={true}
+        >
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            Avocado
+          </td>
+          <td
+            attribute={null}
+            cellRender={null}
+            data-radium={true}
+            header={null}
+            style={
+              Object {
+                "background": "#FFFFFF",
+                "fontSize": "14px",
+                "fontWeight": 400,
+                "height": 48,
+                "lineHeight": "48px",
+                "padding": "0 16px",
+                "textAlign": "left",
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
+            vegetable
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;

--- a/src/components/Table/__tests__/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__tests__/__snapshots__/Table.spec.js.snap
@@ -25,6 +25,7 @@ exports[`renders Table with cellRender methods correctly 1`] = `
           data-radium={true}
         >
           <th
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             style={
               Object {
@@ -42,6 +43,7 @@ exports[`renders Table with cellRender methods correctly 1`] = `
             Name
           </th>
           <th
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             style={
               Object {
@@ -59,6 +61,7 @@ exports[`renders Table with cellRender methods correctly 1`] = `
             Type
           </th>
           <th
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             style={
               Object {
@@ -86,6 +89,7 @@ exports[`renders Table with cellRender methods correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -106,6 +110,7 @@ exports[`renders Table with cellRender methods correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -126,6 +131,7 @@ exports[`renders Table with cellRender methods correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -150,6 +156,7 @@ exports[`renders Table with cellRender methods correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -170,6 +177,7 @@ exports[`renders Table with cellRender methods correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -190,6 +198,7 @@ exports[`renders Table with cellRender methods correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -214,6 +223,7 @@ exports[`renders Table with cellRender methods correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -234,6 +244,7 @@ exports[`renders Table with cellRender methods correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -254,6 +265,7 @@ exports[`renders Table with cellRender methods correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -278,6 +290,7 @@ exports[`renders Table with cellRender methods correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -298,6 +311,7 @@ exports[`renders Table with cellRender methods correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -318,6 +332,7 @@ exports[`renders Table with cellRender methods correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -342,7 +357,15 @@ exports[`renders Table with cellRender methods correctly 1`] = `
   <style
     dangerouslySetInnerHTML={
       Object {
-        "__html": "",
+        "__html": "@media (min-width: 832px) and (max-width: 1039px){ .rmq-2f1417d4{height: 32px !important;
+line-height: 32px !important;
+padding: 0 8px !important;}}
+@media (min-width: 768px) and (max-width: 831px){ .rmq-1684b3e4{font-size: 12px !important;
+height: 24px !important;
+line-height: 24px !important;}}
+@media (max-width: 767px){ .rmq-313882e8{font-size: 12px !important;
+height: 24px !important;
+line-height: 24px !important;}}",
       }
     }
   />
@@ -374,6 +397,7 @@ exports[`renders Table with definition headers correctly 1`] = `
           data-radium={true}
         >
           <th
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             style={
               Object {
@@ -391,6 +415,7 @@ exports[`renders Table with definition headers correctly 1`] = `
             Type
           </th>
           <th
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             style={
               Object {
@@ -408,6 +433,7 @@ exports[`renders Table with definition headers correctly 1`] = `
             Name
           </th>
           <th
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             style={
               Object {
@@ -435,6 +461,7 @@ exports[`renders Table with definition headers correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -455,6 +482,7 @@ exports[`renders Table with definition headers correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -475,6 +503,7 @@ exports[`renders Table with definition headers correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -499,6 +528,7 @@ exports[`renders Table with definition headers correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -519,6 +549,7 @@ exports[`renders Table with definition headers correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -539,6 +570,7 @@ exports[`renders Table with definition headers correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -563,6 +595,7 @@ exports[`renders Table with definition headers correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -583,6 +616,7 @@ exports[`renders Table with definition headers correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -603,6 +637,7 @@ exports[`renders Table with definition headers correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -627,6 +662,7 @@ exports[`renders Table with definition headers correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -647,6 +683,7 @@ exports[`renders Table with definition headers correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -667,6 +704,7 @@ exports[`renders Table with definition headers correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -691,7 +729,15 @@ exports[`renders Table with definition headers correctly 1`] = `
   <style
     dangerouslySetInnerHTML={
       Object {
-        "__html": "",
+        "__html": "@media (min-width: 832px) and (max-width: 1039px){ .rmq-2f1417d4{height: 32px !important;
+line-height: 32px !important;
+padding: 0 8px !important;}}
+@media (min-width: 768px) and (max-width: 831px){ .rmq-1684b3e4{font-size: 12px !important;
+height: 24px !important;
+line-height: 24px !important;}}
+@media (max-width: 767px){ .rmq-313882e8{font-size: 12px !important;
+height: 24px !important;
+line-height: 24px !important;}}",
       }
     }
   />
@@ -723,6 +769,7 @@ exports[`renders Table with minimal definition correctly 1`] = `
           data-radium={true}
         >
           <th
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             style={
               Object {
@@ -740,6 +787,7 @@ exports[`renders Table with minimal definition correctly 1`] = `
             name
           </th>
           <th
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             style={
               Object {
@@ -767,6 +815,7 @@ exports[`renders Table with minimal definition correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -787,6 +836,7 @@ exports[`renders Table with minimal definition correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -811,6 +861,7 @@ exports[`renders Table with minimal definition correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -831,6 +882,7 @@ exports[`renders Table with minimal definition correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -855,6 +907,7 @@ exports[`renders Table with minimal definition correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -875,6 +928,7 @@ exports[`renders Table with minimal definition correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -899,6 +953,7 @@ exports[`renders Table with minimal definition correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -919,6 +974,7 @@ exports[`renders Table with minimal definition correctly 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -943,7 +999,15 @@ exports[`renders Table with minimal definition correctly 1`] = `
   <style
     dangerouslySetInnerHTML={
       Object {
-        "__html": "",
+        "__html": "@media (min-width: 832px) and (max-width: 1039px){ .rmq-2f1417d4{height: 32px !important;
+line-height: 32px !important;
+padding: 0 8px !important;}}
+@media (min-width: 768px) and (max-width: 831px){ .rmq-1684b3e4{font-size: 12px !important;
+height: 24px !important;
+line-height: 24px !important;}}
+@media (max-width: 767px){ .rmq-313882e8{font-size: 12px !important;
+height: 24px !important;
+line-height: 24px !important;}}",
       }
     }
   />
@@ -977,6 +1041,7 @@ exports[`renders Table without header if specified 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -997,6 +1062,7 @@ exports[`renders Table without header if specified 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -1021,6 +1087,7 @@ exports[`renders Table without header if specified 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -1041,6 +1108,7 @@ exports[`renders Table without header if specified 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -1065,6 +1133,7 @@ exports[`renders Table without header if specified 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -1085,6 +1154,7 @@ exports[`renders Table without header if specified 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -1109,6 +1179,7 @@ exports[`renders Table without header if specified 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -1129,6 +1200,7 @@ exports[`renders Table without header if specified 1`] = `
           <td
             attribute={null}
             cellRender={null}
+            className="rmq-2f1417d4 rmq-1684b3e4 rmq-313882e8"
             data-radium={true}
             header={null}
             style={
@@ -1153,7 +1225,15 @@ exports[`renders Table without header if specified 1`] = `
   <style
     dangerouslySetInnerHTML={
       Object {
-        "__html": "",
+        "__html": "@media (min-width: 832px) and (max-width: 1039px){ .rmq-2f1417d4{height: 32px !important;
+line-height: 32px !important;
+padding: 0 8px !important;}}
+@media (min-width: 768px) and (max-width: 831px){ .rmq-1684b3e4{font-size: 12px !important;
+height: 24px !important;
+line-height: 24px !important;}}
+@media (max-width: 767px){ .rmq-313882e8{font-size: 12px !important;
+height: 24px !important;
+line-height: 24px !important;}}",
       }
     }
   />

--- a/src/components/Table/docs/Table.md
+++ b/src/components/Table/docs/Table.md
@@ -12,7 +12,7 @@ Tables consist of displayed `data` and a `definition` used to lay out the rows.
         definition={[
           { header: 'Name', attribute: 'name' },
           { header: 'Type', attribute: 'type' },
-          { header: '👇', attribute: 'emoji' }
+          { header: '🛒', attribute: 'emoji' }
         ]}
       />
     </div>

--- a/src/components/Table/docs/Table.md
+++ b/src/components/Table/docs/Table.md
@@ -1,4 +1,4 @@
-Table example:
+Tables consist of displayed `data` and a `definition` used to lay out the rows.
 
 ```jsx
     <div>
@@ -32,8 +32,8 @@ Individual cells can have their own click handler as well, using `onClick` withi
           { name: 'Avocado', title: 'VEGETABLE', emoji: '🥑' }
         ]}
         definition={[
-          { header: 'Name', attribute: 'name', onClick: rowData => alert(`Cell click for "${rowData.name}"`) },
-          { header: 'Title', attribute: 'title', cellRender: (name, rowIndex, rowData) => (<span>{name.toLowerCase()}</span>) }
+          { attribute: 'name', onClick: rowData => { alert(`Clicked on cell "${rowData.name}"`) } },
+          { attribute: 'title', cellRender: (name, rowIndex, rowData) => (<span>{name.toLowerCase()}</span>) }
         ]}
         onRowClick={rowData => {
           alert(rowData.emoji.repeat(3))

--- a/src/components/Table/docs/Table.md
+++ b/src/components/Table/docs/Table.md
@@ -1,0 +1,12 @@
+Table example:
+
+    <Table
+      data={[
+        { name: 'TIM', title: 'engineer' },
+        { name: 'Cosmo', title: 'cat' }
+      ]}
+      definition={[
+        { attribute: 'name', header: 'Name', cellRender: name => (<span>{name.toLowerCase()}) },
+        { attribute: 'title', header: 'Title' }
+      ]}
+    />

--- a/src/components/Table/docs/Table.md
+++ b/src/components/Table/docs/Table.md
@@ -3,19 +3,40 @@ Table example:
 ```jsx
     <div>
       <Table
-        withHeader={true}
         data={[
-          { name: 'Apple', title: 'fruit', emoji: '🍎' },
-          { name: 'CARROT', title: 'vegetable', emoji: '🥕' },
-          { name: 'Lemon', title: 'fruit', emoji: '🍋' },
-          { name: 'Avocado', title: 'VEGETABLE', emoji: '🥑' }
+          { name: 'Apple', title: 'fruit' },
+          { name: 'Carrot', title: 'vegetable' },
+          { name: 'Lemon', title: 'fruit' },
+          { name: 'Avocado', title: 'VEGETABLE' }
         ]}
         definition={[
           { header: 'Name', attribute: 'name' },
           { header: 'Title', attribute: 'title', cellRender: (name, rowIndex, rowData) => (<span>{name.toLowerCase()}</span>) }
         ]}
+      />
+    </div>
+```
+
+You can apply row click events with the prop `onRowClick`
+
+Individual cells can have their own click handler as well, using `onClick` within a `definition`. These will override any applied `onRowClick`.
+
+```jsx
+    <div>
+      <Table
+        withHeader={false}
+        data={[
+          { name: 'Apple', title: 'fruit', emoji: '🍎' },
+          { name: 'Carrot', title: 'vegetable', emoji: '🥕' },
+          { name: 'Lemon', title: 'fruit', emoji: '🍋' },
+          { name: 'Avocado', title: 'VEGETABLE', emoji: '🥑' }
+        ]}
+        definition={[
+          { header: 'Name', attribute: 'name', onClick: rowData => alert(`Cell click for "${rowData.name}"`) },
+          { header: 'Title', attribute: 'title', cellRender: (name, rowIndex, rowData) => (<span>{name.toLowerCase()}</span>) }
+        ]}
         onRowClick={rowData => {
-          alert(rowData.emoji)
+          alert(rowData.emoji.repeat(3))
         }}
       />
     </div>

--- a/src/components/Table/docs/Table.md
+++ b/src/components/Table/docs/Table.md
@@ -4,40 +4,16 @@ Tables consist of displayed `data` and a `definition` used to lay out the rows.
     <div>
       <Table
         data={[
-          { name: 'Apple', title: 'fruit' },
-          { name: 'Carrot', title: 'vegetable' },
-          { name: 'Lemon', title: 'fruit' },
-          { name: 'Avocado', title: 'VEGETABLE' }
-        ]}
-        definition={[
-          { header: 'Name', attribute: 'name' },
-          { header: 'Title', attribute: 'title', cellRender: (name, rowIndex, rowData) => (<span>{name.toLowerCase()}</span>) }
-        ]}
-      />
-    </div>
-```
-
-You can apply row click events with the prop `onRowClick`
-
-Individual cells can have their own click handler as well, using `onClick` within a `definition`. These will override any applied `onRowClick`.
-
-```jsx
-    <div>
-      <Table
-        withHeader={false}
-        data={[
           { name: 'Apple', title: 'fruit', emoji: '🍎' },
           { name: 'Carrot', title: 'vegetable', emoji: '🥕' },
           { name: 'Lemon', title: 'fruit', emoji: '🍋' },
           { name: 'Avocado', title: 'VEGETABLE', emoji: '🥑' }
         ]}
         definition={[
-          { attribute: 'name', onClick: rowData => { alert(`Clicked on cell "${rowData.name}"`) } },
-          { attribute: 'title', cellRender: (name, rowIndex, rowData) => (<span>{name.toLowerCase()}</span>) }
+          { header: 'Name', attribute: 'name' },
+          { header: 'Title', attribute: 'title', cellRender: (name, rowIndex, rowData) => (<span>{name.toLowerCase()}</span>) },
+          { header: '👇', attribute: 'emoji' }
         ]}
-        onRowClick={rowData => {
-          alert(rowData.emoji.repeat(3))
-        }}
       />
     </div>
 ```

--- a/src/components/Table/docs/Table.md
+++ b/src/components/Table/docs/Table.md
@@ -1,12 +1,22 @@
 Table example:
 
-    <Table
-      data={[
-        { name: 'TIM', title: 'engineer' },
-        { name: 'Cosmo', title: 'cat' }
-      ]}
-      definition={[
-        { attribute: 'name', header: 'Name', cellRender: name => (<span>{name.toLowerCase()}) },
-        { attribute: 'title', header: 'Title' }
-      ]}
-    />
+```jsx
+    <div>
+      <Table
+        withHeader={true}
+        data={[
+          { name: 'Apple', title: 'fruit', emoji: '🍎' },
+          { name: 'CARROT', title: 'vegetable', emoji: '🥕' },
+          { name: 'Lemon', title: 'fruit', emoji: '🍋' },
+          { name: 'Avocado', title: 'VEGETABLE', emoji: '🥑' }
+        ]}
+        definition={[
+          { header: 'Name', attribute: 'name' },
+          { header: 'Title', attribute: 'title', cellRender: (name, rowIndex, rowData) => (<span>{name.toLowerCase()}</span>) }
+        ]}
+        onRowClick={rowData => {
+          alert(rowData.emoji)
+        }}
+      />
+    </div>
+```

--- a/src/components/Table/docs/Table.md
+++ b/src/components/Table/docs/Table.md
@@ -4,15 +4,35 @@ Tables consist of displayed `data` and a `definition` used to lay out the rows.
     <div>
       <Table
         data={[
-          { name: 'Apple', title: 'fruit', emoji: '🍎' },
-          { name: 'Carrot', title: 'vegetable', emoji: '🥕' },
-          { name: 'Lemon', title: 'fruit', emoji: '🍋' },
-          { name: 'Avocado', title: 'VEGETABLE', emoji: '🥑' }
+          { name: 'Apple', type: 'fruit', emoji: '🍎' },
+          { name: 'Carrot', type: 'vegetable', emoji: '🥕' },
+          { name: 'Lemon', type: 'fruit', emoji: '🍋' },
+          { name: 'Avocado', type: 'vegetable', emoji: '🥑' }
         ]}
         definition={[
           { header: 'Name', attribute: 'name' },
-          { header: 'Title', attribute: 'title', cellRender: (name, rowIndex, rowData) => (<span>{name.toLowerCase()}</span>) },
+          { header: 'Type', attribute: 'type' },
           { header: '👇', attribute: 'emoji' }
+        ]}
+      />
+    </div>
+```
+
+You can provide a specific render method for each cell, as well.
+
+```jsx
+    <div>
+      <Table
+        data={[
+          { name: 'Apple', type: 'fruit', preference: 0.64 },
+          { name: 'Carrot', type: 'vegetable', preference: 1.00 },
+          { name: 'Lemon', type: 'fruit', preference: 0.20 },
+          { name: 'Avocado', type: 'vegetable', preference: 0.86 }
+        ]}
+        definition={[
+          { header: 'Name', attribute: 'name' },
+          { header: 'Type', attribute: 'type' },
+          { header: 'User Preference', attribute: 'preference', cellRender: (preference, rowIndex, rowData) => (<span>{preference * 100}%</span>) }
         ]}
       />
     </div>

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -112,6 +112,10 @@ module.exports = {
           components: 'src/components/ScrollTrack/[A-Z]*.js'
         },
         {
+          name: 'Table',
+          components: 'src/components/Table/Table.js'
+        },
+        {
           name: 'Tooltip',
           components: 'src/components/Tooltip/Tooltip.js'
         },


### PR DESCRIPTION
Adding support for `<Table/>`

```jsx
<Table
  data={[
    { name: 'Apple', title: 'fruit' },
    { name: 'Carrot', title: 'vegetable' },
    { name: 'Lemon', title: 'fruit' },
    { name: 'Avocado', title: 'VEGETABLE' }
  ]}
  definition={[
    { header: 'Name', attribute: 'name' },
    { header: 'Title', attribute: 'title', cellRender: (name, rowIndex, rowData) => (<span>{name.toLowerCase()}</span>) }
  ]}
/>
```

returns

<img width="1487" alt="screen shot 2018-09-17 at 5 33 27 pm" src="https://user-images.githubusercontent.com/52420/45657576-d4f20f80-ba9f-11e8-9dac-022448477c4e.png">
