### PR TITLE
fix for IE 11 bug

### DIFF
--- a/src/utils/isEqual.js
+++ b/src/utils/isEqual.js
@@ -65,8 +65,8 @@ const arraysUnequal = (a, b, aStack, bStack) => { // eslint-disable-line max-par
 const deepEq = (a, b, aStack, bStack) => { // eslint-disable-line max-params
   if (a._wrapped) a = a._wrapped
   if (b._wrapped) b = b._wrapped
-  const className = toString.call(a)
-  if (className !== toString.call(b)) return false
+  const className = Object.prototype.toString.call(a)
+  if (className !== Object.prototype.toString.call(b)) return false
 
   const classNameDerivedBoolean = fromClassName(className, a, b)
 


### PR DESCRIPTION
the most recent update to snacks introduced an issue in IE11

`TypeError: Invalid calling object`

This issue stemmed from `isEqual` using `toString` without referencing the `Object.prototype`

I was able to recreate in IE11 on browserstack

![screen shot 2018-09-21 at 12 12 26 pm](https://user-images.githubusercontent.com/3149916/45893285-c43fe300-bd98-11e8-95e5-d550f1f2fc2f.png)
