### PR TITLE
Pass aria-haspopup and aria-expanded as props in Button

### DIFF
--- a/src/components/Buttons/Button.js
+++ b/src/components/Buttons/Button.js
@@ -238,6 +238,8 @@ const Button = props => {
 
       props.onMouseDown(e, props)
     },
+    'aria-haspopup': props['aria-haspopup'],
+    'aria-expanded': props['aria-expanded'],
     ...props.elementAttributes
   }
   if (props.href) {
@@ -320,7 +322,13 @@ Button.propTypes = {
   elementAttributes: PropTypes.object,
 
   /** Snacks theme attributes provided by `Themer` */
-  snacksTheme: themePropTypes
+  snacksTheme: themePropTypes,
+
+  /** Indicates to screen readers that the button has a popup context menu  */
+  'aria-haspopup': PropTypes.bool,
+
+  /** Indicates to screen readers whether the button is currently opened  */
+  'aria-expanded': PropTypes.bool,
 }
 
 Button.defaultProps = {
@@ -332,7 +340,9 @@ Button.defaultProps = {
   onClick: noop,
   onMouseDown: noop,
   inverted: false,
-  elementAttributes: {}
+  elementAttributes: {},
+  'aria-haspopup': false,
+  'aria-expanded': null,
 }
 
 export default withTheme(Radium(Button))

--- a/src/components/Buttons/__tests__/__snapshots__/Button.spec.js.snap
+++ b/src/components/Buttons/__tests__/__snapshots__/Button.spec.js.snap
@@ -5,6 +5,8 @@ exports[`Button applies the elementAttributes prop correctly 1`] = `
   data-radium={true}
 >
   <button
+    aria-expanded={null}
+    aria-haspopup={false}
     aria-label="foo"
     data-radium={true}
     disabled={false}
@@ -58,6 +60,8 @@ exports[`Button can render as a link if an href is provided 1`] = `
   data-radium={true}
 >
   <a
+    aria-expanded={null}
+    aria-haspopup={false}
     data-radium={true}
     disabled={false}
     href="/carrot"
@@ -112,6 +116,8 @@ exports[`Button renders all sizes correctly 1`] = `
   data-radium={true}
 >
   <button
+    aria-expanded={null}
+    aria-haspopup={false}
     data-radium={true}
     disabled={false}
     onBlur={[Function]}
@@ -165,6 +171,8 @@ exports[`Button renders all sizes correctly 2`] = `
   data-radium={true}
 >
   <button
+    aria-expanded={null}
+    aria-haspopup={false}
     data-radium={true}
     disabled={false}
     onBlur={[Function]}
@@ -217,6 +225,8 @@ exports[`Button renders all sizes correctly 3`] = `
   data-radium={true}
 >
   <button
+    aria-expanded={null}
+    aria-haspopup={false}
     data-radium={true}
     disabled={false}
     onBlur={[Function]}
@@ -269,6 +279,8 @@ exports[`Button renders all sizes correctly 4`] = `
   data-radium={true}
 >
   <button
+    aria-expanded={null}
+    aria-haspopup={false}
     data-radium={true}
     disabled={false}
     onBlur={[Function]}
@@ -321,6 +333,8 @@ exports[`Button renders all snacks button variants correctly 1`] = `
   data-radium={true}
 >
   <button
+    aria-expanded={null}
+    aria-haspopup={false}
     data-radium={true}
     disabled={false}
     onBlur={[Function]}
@@ -373,6 +387,8 @@ exports[`Button renders all snacks button variants correctly 2`] = `
   data-radium={true}
 >
   <button
+    aria-expanded={null}
+    aria-haspopup={false}
     data-radium={true}
     disabled={false}
     onBlur={[Function]}
@@ -425,6 +441,8 @@ exports[`Button renders all snacks button variants correctly 3`] = `
   data-radium={true}
 >
   <button
+    aria-expanded={null}
+    aria-haspopup={false}
     data-radium={true}
     disabled={false}
     onBlur={[Function]}
@@ -477,6 +495,8 @@ exports[`Button renders all snacks button variants correctly 4`] = `
   data-radium={true}
 >
   <button
+    aria-expanded={null}
+    aria-haspopup={false}
     data-radium={true}
     disabled={false}
     onBlur={[Function]}
@@ -529,6 +549,8 @@ exports[`Button renders correctly when disabled 1`] = `
   data-radium={true}
 >
   <button
+    aria-expanded={null}
+    aria-haspopup={false}
     data-radium={true}
     disabled={true}
     onBlur={[Function]}
@@ -577,6 +599,8 @@ exports[`Button renders icons correctly 1`] = `
   data-radium={true}
 >
   <button
+    aria-expanded={null}
+    aria-haspopup={false}
     data-radium={true}
     disabled={false}
     onBlur={[Function]}
@@ -659,6 +683,8 @@ exports[`Button renders icons correctly 2`] = `
   data-radium={true}
 >
   <button
+    aria-expanded={null}
+    aria-haspopup={false}
     data-radium={true}
     disabled={false}
     onBlur={[Function]}
@@ -741,6 +767,8 @@ exports[`Button renders icons correctly 3`] = `
   data-radium={true}
 >
   <button
+    aria-expanded={null}
+    aria-haspopup={false}
     data-radium={true}
     disabled={false}
     onBlur={[Function]}
@@ -823,6 +851,8 @@ exports[`Button renders icons correctly 4`] = `
   data-radium={true}
 >
   <button
+    aria-expanded={null}
+    aria-haspopup={false}
     data-radium={true}
     disabled={false}
     onBlur={[Function]}
@@ -905,6 +935,8 @@ exports[`Button renders with inverted colors 1`] = `
   data-radium={true}
 >
   <button
+    aria-expanded={null}
+    aria-haspopup={false}
     data-radium={true}
     disabled={false}
     onBlur={[Function]}

--- a/src/components/Menus/__tests__/__snapshots__/DropdownMenu.spec.js.snap
+++ b/src/components/Menus/__tests__/__snapshots__/DropdownMenu.spec.js.snap
@@ -19,6 +19,8 @@ exports[`renders DropdownMenu with icons and trigger correctly 1`] = `
         }
       >
         <button
+          aria-expanded={false}
+          aria-haspopup={true}
           data-radium={true}
           disabled={false}
           onBlur={[Function]}


### PR DESCRIPTION
`DropDownMenu` adds the `aria-haspopup` and `aria-expanded` attributes to the `triggerElement`; however, the current `Button` only accepts those attributes if added through `elementAttributes`. 

This change explicitly passes the props in order to allow the `DropDownMenu` to be controlled by a snacks `Button` and retain the correct screen reader attributes.

@nbwar @dcocchia  