### PR TITLE
Add elementAttributes in DropDownMenu

### DIFF
--- a/src/components/Forms/__tests__/__snapshots__/Select.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/Select.spec.js.snap
@@ -37,6 +37,12 @@ exports[`renders Select correctly 1`] = `
               aria-expanded={false}
               aria-haspopup={true}
               data-radium={true}
+              elementAttributes={
+                Object {
+                  "aria-expanded": false,
+                  "aria-haspopup": true,
+                }
+              }
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseDown={[Function]}
@@ -407,6 +413,12 @@ exports[`renders Select w/ server error correctly 1`] = `
               aria-expanded={false}
               aria-haspopup={true}
               data-radium={true}
+              elementAttributes={
+                Object {
+                  "aria-expanded": false,
+                  "aria-haspopup": true,
+                }
+              }
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseDown={[Function]}
@@ -779,6 +791,12 @@ exports[`renders disabled Select correctly 1`] = `
               aria-expanded={false}
               aria-haspopup={true}
               data-radium={true}
+              elementAttributes={
+                Object {
+                  "aria-expanded": false,
+                  "aria-haspopup": true,
+                }
+              }
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseDown={[Function]}
@@ -1149,6 +1167,12 @@ exports[`renders invalid Select correctly 1`] = `
               aria-expanded={false}
               aria-haspopup={true}
               data-radium={true}
+              elementAttributes={
+                Object {
+                  "aria-expanded": false,
+                  "aria-haspopup": true,
+                }
+              }
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseDown={[Function]}
@@ -1518,6 +1542,12 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
             aria-expanded={false}
             aria-haspopup={true}
             data-radium={true}
+            elementAttributes={
+              Object {
+                "aria-expanded": false,
+                "aria-haspopup": true,
+              }
+            }
             onBlur={[Function]}
             onFocus={[Function]}
             onMouseDown={[Function]}

--- a/src/components/Menus/DropdownMenu.js
+++ b/src/components/Menus/DropdownMenu.js
@@ -180,6 +180,10 @@ class DropdownMenu extends React.Component {
           }
         },
         onMouseDown: this.handleClick,
+        elementAttributes: {
+          'aria-haspopup': true,
+          'aria-expanded': open,
+        },
         'aria-haspopup': true,
         'aria-expanded': open,
       })

--- a/src/components/Menus/__tests__/__snapshots__/DropdownMenu.spec.js.snap
+++ b/src/components/Menus/__tests__/__snapshots__/DropdownMenu.spec.js.snap
@@ -19,6 +19,8 @@ exports[`renders DropdownMenu with icons and trigger correctly 1`] = `
         }
       >
         <button
+          aria-expanded={false}
+          aria-haspopup={true}
           data-radium={true}
           disabled={false}
           onBlur={[Function]}


### PR DESCRIPTION
Add `'aria-haspopup': true` and `'aria-expanded': open,` as `elementAttributes` so that it will be properly pass as props and spread to the underlying html element.

@dcocchia @nbwar 