### PR TITLE
client-side a11y autofocus support for Form when fail to validate

### DIFF
--- a/src/components/Forms/Form.js
+++ b/src/components/Forms/Form.js
@@ -5,13 +5,15 @@ import isEqual from '../../utils/isEqual'
 class Form extends React.Component {
   static propTypes = {
     /** Form html chilren */
-    children    : PropTypes.node,
+    children         : PropTypes.node,
     /** HTML form attributes */
-    formProps   : PropTypes.shape({}),
+    formProps        : PropTypes.shape({}),
     /** onSubmit callback will pass in model as parameter */
-    onSubmit    : PropTypes.func,
+    onSubmit         : PropTypes.func,
+    /** onValidationError callback will pass in invalid FormComponents as parameter*/
+    onValidationError: PropTypes.func,
     /** errors from server mapped to model names. Will attach serverErrors styling to FormComppnents */
-    serverErrors: PropTypes.shape({})
+    serverErrors     : PropTypes.shape({})
   }
 
   static childContextTypes = {
@@ -20,9 +22,10 @@ class Form extends React.Component {
 
   constructor() {
     super()
-    this.state          = { serverErrors: null }
-    this.model          = {}
-    this.formComponents = {}
+    this.state             = { serverErrors: null }
+    this.model             = {}
+    this.formComponents    = {}
+    this.invalidComponents = []
   }
 
   getChildContext() {
@@ -67,7 +70,8 @@ class Form extends React.Component {
 
   formIsValid() {
     const components = Object.values(this.formComponents)
-    return components.every( component => component.validate() )
+    this.invalidComponents = components.filter(component => !component.validate())
+    return this.invalidComponents.length === 0
   }
 
   updateModel() {
@@ -89,6 +93,8 @@ class Form extends React.Component {
       this.setState({serverErrors: null}, () => {
         this.props.onSubmit && this.props.onSubmit(this.model)
       })
+    } else {
+      this.props.onValidationError && this.props.onValidationError(this.invalidComponents)
     }
   }
 

--- a/src/components/Forms/FormComponent.js
+++ b/src/components/Forms/FormComponent.js
@@ -40,12 +40,6 @@ const formComponent = (WrappedComponent) => {
       this.context.ICFormable && this.context.ICFormable.unregisterComponent(this)
     }
 
-    triggerFocus = () => {
-      if (typeof this.FormComponent.triggerFocus === 'function') {
-        return this.FormComponent.triggerFocus()
-      }
-    }
-
     getValue = () => {
       if (typeof this.FormComponent.getValue === 'function') {
         // If component getValue function defined on component

--- a/src/components/Forms/FormComponent.js
+++ b/src/components/Forms/FormComponent.js
@@ -10,7 +10,7 @@ const formComponent = (WrappedComponent) => {
       /** Disable the input; Will be removed from model in Form onSubmit callback */
       disabled       : PropTypes.bool,
       /** Uniq id for input */
-      id                 : PropTypes.string,
+      id             : PropTypes.string,
       /** Mark input as required */
       required       : PropTypes.bool,
       /** Regex Validation pattern */
@@ -38,6 +38,12 @@ const formComponent = (WrappedComponent) => {
 
     componentWillUnmount() {
       this.context.ICFormable && this.context.ICFormable.unregisterComponent(this)
+    }
+
+    triggerFocus = () => {
+      if (typeof this.FormComponent.triggerFocus === 'function') {
+        return this.FormComponent.triggerFocus()
+      }
     }
 
     getValue = () => {
@@ -124,5 +130,3 @@ const formComponent = (WrappedComponent) => {
 }
 
 export default formComponent
-
-

--- a/src/components/Forms/PhoneNumberField.js
+++ b/src/components/Forms/PhoneNumberField.js
@@ -191,10 +191,6 @@ class PhoneNumberField extends React.Component {
     return this.input.value.replace(phoneRegex, '')
   }
 
-  triggerFocus = () => {
-    this.input.focus()
-  }
-
   handleInputChange = (e) => {
     const { onChange } = this.props
     const { hasValue } = this.state
@@ -222,6 +218,8 @@ class PhoneNumberField extends React.Component {
   handleKeyDown = (e) => {
     this.props.onKeyDown(e)
   }
+
+  triggerFocus = () => this.input.focus()
 
   render() {
     const {

--- a/src/components/Forms/PhoneNumberField.js
+++ b/src/components/Forms/PhoneNumberField.js
@@ -133,13 +133,13 @@ class PhoneNumberField extends React.Component {
     isValid            : PropTypes.bool,
     /** onFocus callback */
     onFocus            : PropTypes.func,
-    /** onChange callback 
-     * 
+    /** onChange callback
+     *
      * @param {SyntheticEvent} event The react `SyntheticEvent`
      * @param {String} value The value from the input with `(`, `)`, space, and `-` characters removed
      * @param {String} rawValue The raw value from the input
     */
-    
+
     onChange           : PropTypes.func,
     /** onBlur callback */
     onBlur             : PropTypes.func,
@@ -189,6 +189,10 @@ class PhoneNumberField extends React.Component {
     }
 
     return this.input.value.replace(phoneRegex, '')
+  }
+
+  triggerFocus = () => {
+    this.input.focus()
   }
 
   handleInputChange = (e) => {
@@ -326,4 +330,3 @@ class PhoneNumberField extends React.Component {
 }
 
 export default PhoneNumberField
-

--- a/src/components/Forms/TextField.js
+++ b/src/components/Forms/TextField.js
@@ -148,6 +148,10 @@ class TextField extends React.Component {
     }
   }
 
+  triggerFocus = () => {
+    this.input.focus()
+  }
+
   getValue = () => {
     if (!this.input) {
       return null

--- a/src/components/Forms/TextField.js
+++ b/src/components/Forms/TextField.js
@@ -148,10 +148,6 @@ class TextField extends React.Component {
     }
   }
 
-  triggerFocus = () => {
-    this.input.focus()
-  }
-
   getValue = () => {
     if (!this.input) {
       return null
@@ -187,6 +183,8 @@ class TextField extends React.Component {
   handleKeyDown = (e) => {
     this.props.onKeyDown(e)
   }
+
+  triggerFocus = () => this.input.focus()
 
   render() {
     const {

--- a/src/components/Forms/__tests__/Form.spec.js
+++ b/src/components/Forms/__tests__/Form.spec.js
@@ -89,11 +89,13 @@ it('wont fire the onSubmit prop when not valid', () => {
   expect(onSubmit.calledOnce).toBe(false)
 })
 
-it('wont fire the onSubmit prop when not valid', () => {
+it('fire the onValidationError prop when not valid', () => {
   const onSubmit = spy()
+  const onValidationError = spy()
   const wrapper = mount(
     <Form
       onSubmit={onSubmit}
+      onValidationError={onValidationError}
     >
       <div style={{width: '335px'}}>
         <div style={{marginBottom: '10px'}}>
@@ -119,5 +121,5 @@ it('wont fire the onSubmit prop when not valid', () => {
   stub(wrapper.instance(), 'updateModel').callsFake(() => {})
 
   wrapper.find(Button).simulate('submit')
-  expect(onSubmit.calledOnce).toBe(false)
+  expect(onValidationError.calledOnce).toBe(true)
 })

--- a/src/components/Forms/__tests__/PhoneNumberField.spec.js
+++ b/src/components/Forms/__tests__/PhoneNumberField.spec.js
@@ -35,7 +35,7 @@ it('renders correctly', () => {
       </div>
     </StyleRoot>
   )
-  
+
   expect(toJson(wrapper)).toMatchSnapshot()
 })
 
@@ -54,7 +54,7 @@ it('renders correctly with focus state', () => {
   )
 
   wrapper.find('input').simulate('focus')
-  
+
   expect(toJson(wrapper)).toMatchSnapshot()
 })
 
@@ -78,6 +78,26 @@ it('fires the onFocus prop', () => {
 
   expect(onFocus).toBeCalled()
   expect(onFocus.mock.calls.length).toBe(1)
+})
+
+it('fires the triggerFocus method', () => {
+  const wrapper = mount(
+    <StyleRoot>
+      <div>
+        <PhoneNumberField
+          id="test_id"
+          name="test"
+          floatingLabelText="Phone Number"
+          hintText="(555) 555-555"
+        />
+      </div>
+    </StyleRoot>
+  )
+
+  wrapper.find('PhoneNumberField').first().instance().triggerFocus()
+  setTimeout(() => {
+    expect(wrapper.children().matchesElement(document.activeElement)).toEqual(true, 'The input was not focused')
+  }, 10)
 })
 
 it('fires the onBlur prop', () => {

--- a/src/components/Forms/__tests__/TextField.spec.js
+++ b/src/components/Forms/__tests__/TextField.spec.js
@@ -44,6 +44,27 @@ it('fires the onFocus prop', () => {
   expect(onFocus.calledOnce).toBe(true)
 })
 
+it('fires the triggerFocus method', () => {
+  const wrapper = mount(
+    <StyleRoot>
+      <div>
+        <TextField
+          id="test_id"
+          name="test"
+          type="email"
+          floatingLabelText="Email"
+          hintText="Enter your email address"
+        />
+      </div>
+    </StyleRoot>
+  )
+
+  wrapper.find('TextField').first().instance().triggerFocus()
+  setTimeout(() => {
+    expect(wrapper.children().matchesElement(document.activeElement)).toEqual(true, 'The input was not focused')
+  }, 10)
+})
+
 it('fires the onBlur prop', () => {
   const onBlur = spy()
   const wrapper = mount(

--- a/src/components/Forms/__tests__/TextField.spec.js
+++ b/src/components/Forms/__tests__/TextField.spec.js
@@ -5,20 +5,22 @@ import { mount }     from 'enzyme'
 import { spy }       from 'sinon'
 import TextField     from '../TextField'
 
+const defaultTextField = (
+  <StyleRoot>
+    <div>
+      <TextField
+        id="test_id"
+        name="test"
+        type="email"
+        floatingLabelText="Email"
+        hintText="Enter your email address"
+      />
+    </div>
+  </StyleRoot>
+)
+
 it('renders TextField correctly', () => {
-  const tree = renderer.create(
-    <StyleRoot>
-      <div>
-        <TextField
-          id="test_id"
-          name="test"
-          type="email"
-          floatingLabelText="Email"
-          hintText="Enter your email address"
-        />
-      </div>
-    </StyleRoot>
-  ).toJSON()
+  const tree = renderer.create(defaultTextField).toJSON()
   expect(tree).toMatchSnapshot()
 })
 
@@ -45,19 +47,7 @@ it('fires the onFocus prop', () => {
 })
 
 it('fires the triggerFocus method', () => {
-  const wrapper = mount(
-    <StyleRoot>
-      <div>
-        <TextField
-          id="test_id"
-          name="test"
-          type="email"
-          floatingLabelText="Email"
-          hintText="Enter your email address"
-        />
-      </div>
-    </StyleRoot>
-  )
+  const wrapper = mount(defaultTextField)
 
   wrapper.find('TextField').first().instance().triggerFocus()
   setTimeout(() => {


### PR DESCRIPTION
## What
- Add `onValidationError` callback to `Form`
- Add `triggerFocus` function to `TextField` and `PhoneNumberField`

## Why
Allow users of the library to handle client-side validation errors.
For example, one can use the callback to support a11y autofocus
```
onValidationError={(invalidComponents) => {
  if (invalidComponents && invalidComponents.length > 0) {
    invalidComponents[0].triggerFocus()
  }
}}
```

## Who should review this
@nbwar @dcocchia 