### PR TITLE
Add the ability to add attributes to inner elements

### DIFF
--- a/src/components/NavigationPills/NavigationPill.js
+++ b/src/components/NavigationPills/NavigationPill.js
@@ -44,7 +44,6 @@ const styles = {
 const NavigationPill = props => {
   const { isActive, snacksTheme, text } = props
   const { primaryForeground } = snacksTheme.colors
-  const { inner, ...outer } = props.elementAttributes
   const activeStyles = {
     backgroundColor: primaryForeground,
     color: colors.WHITE,
@@ -53,14 +52,14 @@ const NavigationPill = props => {
       backgroundColor: primaryForeground
     },
     ':focus': {
-      backgroundColor: primaryForeground
+      backgroundColor: primaryForeground,
     }
   }
 
   return (
     <li
       style={styles.container}
-      {...outer}
+      { ...props.elementAttributes }
     >
       <a
         href={props.path || '#'}
@@ -71,7 +70,7 @@ const NavigationPill = props => {
           { color: primaryForeground },
           isActive && activeStyles
         ]}
-        {...inner}
+        {...props.anchorItemAttributes}
         key={`pill-anchor-${text}`}
       >
         {text}
@@ -83,6 +82,9 @@ const NavigationPill = props => {
 NavigationPill.propTypes = {
   /** Any additonal props to add to the element (e.g. data attributes). */
   elementAttributes: PropTypes.object,
+
+  /** Any additonal props to add to the inner a element (e.g. data attributes). */
+  anchorItemAttributes: PropTypes.object,
 
   /** determines wether or not active styles are applied */
   isActive: PropTypes.bool,

--- a/src/components/NavigationPills/NavigationPill.js
+++ b/src/components/NavigationPills/NavigationPill.js
@@ -44,7 +44,7 @@ const styles = {
 const NavigationPill = props => {
   const { isActive, snacksTheme, text } = props
   const { primaryForeground } = snacksTheme.colors
-
+  const { inner, ...outer } = props.elementAttributes
   const activeStyles = {
     backgroundColor: primaryForeground,
     color: colors.WHITE,
@@ -53,14 +53,14 @@ const NavigationPill = props => {
       backgroundColor: primaryForeground
     },
     ':focus': {
-      backgroundColor: primaryForeground,
+      backgroundColor: primaryForeground
     }
   }
 
   return (
     <li
       style={styles.container}
-      { ...props.elementAttributes }
+      {...outer}
     >
       <a
         href={props.path || '#'}
@@ -71,6 +71,7 @@ const NavigationPill = props => {
           { color: primaryForeground },
           isActive && activeStyles
         ]}
+        {...inner}
         key={`pill-anchor-${text}`}
       >
         {text}

--- a/src/components/NavigationPills/NavigationPills.js
+++ b/src/components/NavigationPills/NavigationPills.js
@@ -31,11 +31,13 @@ const styles = {
 }
 
 const NavigationPills = props => {
+  const { inner, ...outer } = props.elementAttributes
   const renderLabel = () => {
     if (!props.label) { return }
 
     return <label style={styles.labelStyles}>{props.label}</label>
   }
+
 
   const renderPill = (pill, idx) => {
     return (
@@ -58,10 +60,10 @@ const NavigationPills = props => {
       <div
         style={wrapperStyles}
         ref='pillsTrack'
-        { ...props.elementAttributes }
+        { ...outer }
       >
         {renderLabel()}
-        <ul style={pillsContainerStyles}>
+        <ul style={pillsContainerStyles} {...inner}>
           {props.pills.map(renderPill)}
         </ul>
       </div>

--- a/src/components/NavigationPills/NavigationPills.js
+++ b/src/components/NavigationPills/NavigationPills.js
@@ -31,7 +31,6 @@ const styles = {
 }
 
 const NavigationPills = props => {
-  const { inner, ...outer } = props.elementAttributes
   const renderLabel = () => {
     if (!props.label) { return }
 
@@ -60,10 +59,10 @@ const NavigationPills = props => {
       <div
         style={wrapperStyles}
         ref='pillsTrack'
-        { ...outer }
+        { ...props.elementAttributes }
       >
         {renderLabel()}
-        <ul style={pillsContainerStyles} {...inner}>
+        <ul style={pillsContainerStyles} { ...props.listItemAttributes} >
           {props.pills.map(renderPill)}
         </ul>
       </div>
@@ -74,6 +73,9 @@ const NavigationPills = props => {
 NavigationPills.propTypes = {
   /** Any additonal props to add to the element (e.g. data attributes). */
   elementAttributes: PropTypes.object,
+
+  /** Any additonal props to add to the inner ul element (e.g. data attributes). */
+  listItemAttributes: PropTypes.object,
 
   /** array of pill objects */
   pills: PropTypes.array,

--- a/src/components/NavigationPills/__tests__/NavigationPill.spec.js
+++ b/src/components/NavigationPills/__tests__/NavigationPill.spec.js
@@ -47,7 +47,8 @@ it('renders inner element attributes on pill correctly', () => {
   const tree = renderer.create(
     <NavigationPill
       text={'pill with attributes'}
-      elementAttributes={{ inner: {ariaLabel:'this is an aria label'}, role:'tab'}}
+      elementAttributes={{ role:'tab'}}
+      anchorItemAttributes={{ariaLabel:'this is an aria label'}}
     />
   ).toJSON()
   expect(tree).toMatchSnapshot()

--- a/src/components/NavigationPills/__tests__/NavigationPill.spec.js
+++ b/src/components/NavigationPills/__tests__/NavigationPill.spec.js
@@ -42,3 +42,13 @@ it('renders element attributes on pill correctly', () => {
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
+
+it('renders inner element attributes on pill correctly', () => {
+  const tree = renderer.create(
+    <NavigationPill
+      text={'pill with attributes'}
+      elementAttributes={{ inner: {ariaLabel:'this is an aria label'}, role:'tab'}}
+    />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/NavigationPills/__tests__/NavigationPills.spec.js
+++ b/src/components/NavigationPills/__tests__/NavigationPills.spec.js
@@ -85,7 +85,8 @@ it('renders NavigationPills with inner elementAttributes correctly', () => {
             onPillClick={(e, pill) => { console.log(pill) }}
             label={'Filter by'}
             activePill={'dom2'}
-            elementAttributes={{inner: {ariaLabel:'this is an aria label'}, role:'tabs'}}
+            elementAttributes={{role:'tabs'}}
+            listItemAttributes={{ariaLabel:'this is an aria label'}}
           />
       </div>
     </StyleRoot>

--- a/src/components/NavigationPills/__tests__/NavigationPills.spec.js
+++ b/src/components/NavigationPills/__tests__/NavigationPills.spec.js
@@ -76,6 +76,23 @@ it('renders NavigationPills with elementAttributes correctly', () => {
   expect(tree).toMatchSnapshot()
 })
 
+it('renders NavigationPills with inner elementAttributes correctly', () => {
+  const tree = renderer.create(
+    <StyleRoot>
+      <div>
+        <NavigationPills
+            pills={ testPills }
+            onPillClick={(e, pill) => { console.log(pill) }}
+            label={'Filter by'}
+            activePill={'dom2'}
+            elementAttributes={{inner: {ariaLabel:'this is an aria label'}, role:'tabs'}}
+          />
+      </div>
+    </StyleRoot>
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
 it('renders NavigationPills with each pill\'s elementAttributes correctly', () => {
   const testPillsElmAttrs = [
     { path: '/store/doms-pizza-store',  text: 'doms', elementAttributes: { 'aria-label': 'doms', role: 'tab' }},

--- a/src/components/NavigationPills/__tests__/__snapshots__/NavigationPill.spec.js.snap
+++ b/src/components/NavigationPills/__tests__/__snapshots__/NavigationPill.spec.js.snap
@@ -173,3 +173,48 @@ exports[`renders inactive pill correctly 1`] = `
   </a>
 </li>
 `;
+
+exports[`renders inner element attributes on pill correctly 1`] = `
+<li
+  data-radium={true}
+  role="tab"
+  style={
+    Object {
+      "display": "inline-block",
+    }
+  }
+>
+  <a
+    ariaLabel="this is an aria label"
+    data-bypass={true}
+    data-radium={true}
+    href="#"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    style={
+      Object {
+        "backgroundColor": "#F7F7F7",
+        "borderRadius": "24px",
+        "color": "#43B02A",
+        "display": "block",
+        "fontSize": "14px",
+        "lineHeight": "1.2",
+        "marginBottom": 0,
+        "marginLeft": "4px",
+        "marginRight": "4px",
+        "marginTop": 0,
+        "paddingBottom": "12px",
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": "12px",
+        "transition": "background-color 150ms ease-in-out",
+      }
+    }
+  >
+    pill with attributes
+  </a>
+</li>
+`;

--- a/src/components/NavigationPills/__tests__/__snapshots__/NavigationPills.spec.js.snap
+++ b/src/components/NavigationPills/__tests__/__snapshots__/NavigationPills.spec.js.snap
@@ -1608,6 +1608,409 @@ webkit-overflow-scrolling: touch !important;}}
 </div>
 `;
 
+exports[`renders NavigationPills with inner elementAttributes correctly 1`] = `
+<div
+  data-radium={true}
+>
+  <div>
+    <div
+      data-radium={true}
+      onKeyDown={[Function]}
+      style={
+        Object {
+          "overflow": "hidden",
+          "position": "relative",
+        }
+      }
+    >
+      <button
+        aria-label="back"
+        className="rmq-4534e6b"
+        data-radium={true}
+        disabled={undefined}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#43B02A",
+            "border": "0",
+            "borderRadius": "50%",
+            "boxShadow": "0 1px 2px 0 rgba(0, 0, 0, 0.26), 0 1px 4px 0 rgba(0, 0, 0, 0.16)",
+            "color": "#FFFFFF",
+            "display": "none",
+            "height": "48px",
+            "left": 8,
+            "lineHeight": "1",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": "5px",
+            "transition": "background-color 150ms ease-in-out",
+            "width": "48px",
+            "zIndex": 100,
+          }
+        }
+      >
+        <i
+          aria-hidden={true}
+          data-radium={true}
+          onClick={undefined}
+          style={
+            Object {
+              "fontFamily": "ic-icons",
+              "fontSize": "20px",
+              "fontSmoothing": "antialiased",
+              "fontStyle": "normal",
+              "fontVariant": "normal",
+              "fontWeight": "normal",
+              "lineHeight": "1",
+              "osxFontSmoothing": "grayscale",
+              "position": "relative",
+              "speak": "none",
+              "textTransform": "none",
+            }
+          }
+        >
+          
+        </i>
+      </button>
+      <div
+        className="rmq-16b35912"
+        data-radium={true}
+        style={
+          Object {
+            "position": "relative",
+            "transform": "translate3d(0px, 0, 0)",
+            "transition": "transform 150ms ease-in-out",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        <div
+          data-radium={true}
+          style={Object {}}
+        >
+          <div
+            data-radium={true}
+            role="tabs"
+            style={
+              Object {
+                "backgroundColor": "#FFFFFF",
+                "boxSizing": "border-box",
+                "display": "inline-block",
+                "height": "56px",
+                "minWidth": "100%",
+                "paddingBottom": 8,
+                "paddingLeft": 24,
+                "paddingRight": 8,
+                "paddingTop": 8,
+              }
+            }
+          >
+            <label
+              data-radium={true}
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+            >
+              Filter by
+            </label>
+            <ul
+              ariaLabel="this is an aria label"
+              data-radium={true}
+              style={
+                Object {
+                  "display": "inline-block",
+                  "marginBottom": "0",
+                  "marginLeft": "0",
+                  "marginRight": "0",
+                  "marginTop": "0",
+                }
+              }
+            >
+              <li
+                data-radium={true}
+                style={
+                  Object {
+                    "display": "inline-block",
+                  }
+                }
+              >
+                <a
+                  data-bypass={true}
+                  data-radium={true}
+                  href="#"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  style={
+                    Object {
+                      "backgroundColor": "#F7F7F7",
+                      "borderRadius": "24px",
+                      "color": "#43B02A",
+                      "display": "block",
+                      "fontSize": "14px",
+                      "lineHeight": "1.2",
+                      "marginBottom": 0,
+                      "marginLeft": "4px",
+                      "marginRight": "4px",
+                      "marginTop": 0,
+                      "paddingBottom": "12px",
+                      "paddingLeft": 16,
+                      "paddingRight": 16,
+                      "paddingTop": "12px",
+                      "transition": "background-color 150ms ease-in-out",
+                    }
+                  }
+                >
+                  doms
+                </a>
+              </li>
+              <li
+                data-radium={true}
+                style={
+                  Object {
+                    "display": "inline-block",
+                  }
+                }
+              >
+                <a
+                  data-bypass={true}
+                  data-radium={true}
+                  href="#"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  style={
+                    Object {
+                      "backgroundColor": "#F7F7F7",
+                      "borderRadius": "24px",
+                      "color": "#43B02A",
+                      "display": "block",
+                      "fontSize": "14px",
+                      "lineHeight": "1.2",
+                      "marginBottom": 0,
+                      "marginLeft": "4px",
+                      "marginRight": "4px",
+                      "marginTop": 0,
+                      "paddingBottom": "12px",
+                      "paddingLeft": 16,
+                      "paddingRight": 16,
+                      "paddingTop": "12px",
+                      "transition": "background-color 150ms ease-in-out",
+                    }
+                  }
+                >
+                  doms1
+                </a>
+              </li>
+              <li
+                data-radium={true}
+                style={
+                  Object {
+                    "display": "inline-block",
+                  }
+                }
+              >
+                <a
+                  data-bypass={true}
+                  data-radium={true}
+                  href="#"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  style={
+                    Object {
+                      "backgroundColor": "#F7F7F7",
+                      "borderRadius": "24px",
+                      "color": "#43B02A",
+                      "display": "block",
+                      "fontSize": "14px",
+                      "lineHeight": "1.2",
+                      "marginBottom": 0,
+                      "marginLeft": "4px",
+                      "marginRight": "4px",
+                      "marginTop": 0,
+                      "paddingBottom": "12px",
+                      "paddingLeft": 16,
+                      "paddingRight": 16,
+                      "paddingTop": "12px",
+                      "transition": "background-color 150ms ease-in-out",
+                    }
+                  }
+                >
+                  doms2
+                </a>
+              </li>
+              <li
+                data-radium={true}
+                style={
+                  Object {
+                    "display": "inline-block",
+                  }
+                }
+              >
+                <a
+                  data-bypass={true}
+                  data-radium={true}
+                  href="#"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  style={
+                    Object {
+                      "backgroundColor": "#F7F7F7",
+                      "borderRadius": "24px",
+                      "color": "#43B02A",
+                      "display": "block",
+                      "fontSize": "14px",
+                      "lineHeight": "1.2",
+                      "marginBottom": 0,
+                      "marginLeft": "4px",
+                      "marginRight": "4px",
+                      "marginTop": 0,
+                      "paddingBottom": "12px",
+                      "paddingLeft": 16,
+                      "paddingRight": 16,
+                      "paddingTop": "12px",
+                      "transition": "background-color 150ms ease-in-out",
+                    }
+                  }
+                >
+                  doms3
+                </a>
+              </li>
+              <li
+                data-radium={true}
+                style={
+                  Object {
+                    "display": "inline-block",
+                  }
+                }
+              >
+                <a
+                  data-bypass={true}
+                  data-radium={true}
+                  href="#"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  style={
+                    Object {
+                      "backgroundColor": "#F7F7F7",
+                      "borderRadius": "24px",
+                      "color": "#43B02A",
+                      "display": "block",
+                      "fontSize": "14px",
+                      "lineHeight": "1.2",
+                      "marginBottom": 0,
+                      "marginLeft": "4px",
+                      "marginRight": "4px",
+                      "marginTop": 0,
+                      "paddingBottom": "12px",
+                      "paddingLeft": 16,
+                      "paddingRight": 16,
+                      "paddingTop": "12px",
+                      "transition": "background-color 150ms ease-in-out",
+                    }
+                  }
+                />
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <button
+        aria-label="next"
+        className="rmq-4534e6b"
+        data-radium={true}
+        disabled={undefined}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#43B02A",
+            "border": "0",
+            "borderRadius": "50%",
+            "boxShadow": "0 1px 2px 0 rgba(0, 0, 0, 0.26), 0 1px 4px 0 rgba(0, 0, 0, 0.16)",
+            "color": "#FFFFFF",
+            "display": "none",
+            "height": "48px",
+            "lineHeight": "1",
+            "position": "absolute",
+            "right": 8,
+            "textAlign": "center",
+            "top": "5px",
+            "transition": "background-color 150ms ease-in-out",
+            "width": "48px",
+            "zIndex": 100,
+          }
+        }
+      >
+        <i
+          aria-hidden={true}
+          data-radium={true}
+          onClick={undefined}
+          style={
+            Object {
+              "fontFamily": "ic-icons",
+              "fontSize": "20px",
+              "fontSmoothing": "antialiased",
+              "fontStyle": "normal",
+              "fontVariant": "normal",
+              "fontWeight": "normal",
+              "lineHeight": "1",
+              "osxFontSmoothing": "grayscale",
+              "position": "relative",
+              "speak": "none",
+              "textTransform": "none",
+            }
+          }
+        >
+          
+        </i>
+      </button>
+    </div>
+  </div>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "@media (max-width: 767px){ .rmq-16b35912{left: inherit !important;
+overflow-x: scroll !important;
+display: block !important;
+-ms-overflow-style: none !important;
+overflow: -moz-scrollbars-none !important;
+webkit-overflow-scrolling: touch !important;}}
+@media (max-width: 767px){ .rmq-4534e6b{display: none !important;}}",
+      }
+    }
+  />
+</div>
+`;
+
 exports[`renders NavigationPills without pills correctly 1`] = `
 <div
   data-radium={true}


### PR DESCRIPTION
For the `NavigationPill` component, proper accessibility requires that certain attributes (eg `aria-selected` and `role=tab`) be placed on the inner `<a>` tag rather than on the `<li>` tag.  

Likewise, for the `NavigationPills` component certain elements should be placed on the inner `<ul>` tag rather than the `<div>` element

This change adds the ability to pass an `inner` object as part of the `elementAttributes` prop.  The change is fully backwards compatible and requires no changes to existing code.