### PR TITLE
Pass the anchorItemAttributes through to pill

### DIFF
--- a/src/components/NavigationPills/NavigationPills.js
+++ b/src/components/NavigationPills/NavigationPills.js
@@ -46,6 +46,7 @@ const NavigationPills = props => {
         text={pill.text}
         key={`pill-${idx}`}
         elementAttributes={pill.elementAttributes}
+        anchorItemAttributes={pill.anchorItemAttributes}
       />
     )
   }


### PR DESCRIPTION
Navigation Pills currently accept `anchorItemAttributes`; however, they are not currently being passed.