### PR TITLE
Increase duplication threshold

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,11 @@
 version: "2" # required to adjust maintainability checks
 checks:
+  duplication:
+    enabled: true
+    config:
+      languages:
+        javascript:
+          mass_threshold: 75
   file-lines:
     config:
       threshold: 500


### PR DESCRIPTION
Moving code climate's duplication threshold from default (45) to 75. Our codebase tends to prefer declarative simplicity over DRYness.