### PR TITLE
Support Overriding Default z-index Values for DropdownMenu and Tooltip

### DIFF
--- a/src/components/Menus/DropdownMenu.js
+++ b/src/components/Menus/DropdownMenu.js
@@ -57,7 +57,9 @@ class DropdownMenu extends React.Component {
     /** Customize style of menu parent */
     menuContainerStyle: PropTypes.shape({}),
     /** Props passed to Menu component */
-    menuProps: PropTypes.shape({})
+    menuProps: PropTypes.shape({}),
+    /** Override the default z-index of the open DropdownMenu container */
+    zIndex: PropTypes.number,
   }
 
   static defaultProps = {
@@ -195,7 +197,8 @@ class DropdownMenu extends React.Component {
       style,
       children,
       menuProps,
-      menuContainerStyle
+      menuContainerStyle,
+      zIndex,
     } = this.props
 
     const isOpen = this.state.open
@@ -212,7 +215,7 @@ class DropdownMenu extends React.Component {
           style={[
             styles.menuContainer,
             menuContainerStyle,
-            isOpen && styles.menuContainerOpen,
+            isOpen && { ...styles.menuContainerOpen, ...zIndex ? { zIndex } : {} },
             !isOpen && styles.menuContainerClosed
           ]}
         >

--- a/src/components/Menus/__tests__/DropdownMenu.spec.js
+++ b/src/components/Menus/__tests__/DropdownMenu.spec.js
@@ -47,3 +47,14 @@ it('should call callbacks correctly', () => {
   expect(onSelect.calledOnce).toBe(true)
   expect(onClose.calledOnce).toBe(true)
 })
+
+it('sets the zIndex correctly when a custom zIndex is specified', () => {
+  const EXPECTED_Z_INDEX = 105824
+  const wrapper = mount(
+    <DropdownMenu zIndex={EXPECTED_Z_INDEX} triggerElement={<Button> Share </Button>}>
+      <MenuItem label="Share via Email" value="email" leftIcon="emailFilled" />
+    </DropdownMenu>)
+
+  wrapper.setProps({open: true})
+  expect(wrapper.find('Slide').parent().props().style.zIndex).toBe(EXPECTED_Z_INDEX)
+})

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -35,6 +35,8 @@ class Tooltip extends PureComponent {
     onDismiss: PropTypes.func,
     onShow: PropTypes.func,
     isVisible: PropTypes.bool,
+    /** Override the default z-index of the Tooltip */
+    zIndex: PropTypes.number,
   }
 
   static defaultProps = {
@@ -92,6 +94,7 @@ class Tooltip extends PureComponent {
       arrowStyle,
       snacksStyle,
       isVisible,
+      zIndex,
     } = this.props
 
     return (
@@ -102,6 +105,7 @@ class Tooltip extends PureComponent {
           target={() => this.trigger}
           show={isVisible || this.state.show}
           onRootClose={this.handleHideToolTip}
+          zIndex={zIndex}
         >
           <InnerToolTip
             size={size}

--- a/src/components/Tooltip/TooltipOverlay.js
+++ b/src/components/Tooltip/TooltipOverlay.js
@@ -19,7 +19,8 @@ class TooltipOverlay extends PureComponent {
       'bottom',
     ]).isRequired,
     onRootClose: PropTypes.func,
-    rootCloseEnabled: PropTypes.bool
+    rootCloseEnabled: PropTypes.bool,
+    zIndex: PropTypes.number,
   }
 
   static defaultProps = {
@@ -27,14 +28,14 @@ class TooltipOverlay extends PureComponent {
   }
 
   render() {
-    const { show, children, target, placement, onRootClose, rootCloseEnabled } = this.props
+    const { show, children, target, placement, onRootClose, rootCloseEnabled, zIndex } = this.props
 
     if (!show) {
       return false
     }
 
     let child = (
-      <TooltipPosition target={target} placement={placement}>
+      <TooltipPosition zIndex={zIndex} target={target} placement={placement}>
         {children}
       </TooltipPosition>
     )

--- a/src/components/Tooltip/TooltipPosition.js
+++ b/src/components/Tooltip/TooltipPosition.js
@@ -26,6 +26,7 @@ class TooltipPosition extends PureComponent {
       'right',
       'bottom',
     ]).isRequired,
+    zIndex: PropTypes.number,
   }
 
   state = {
@@ -122,13 +123,14 @@ class TooltipPosition extends PureComponent {
   }
 
   render() {
-    const { children, placement } = this.props
+    const { children, placement, zIndex } = this.props
     const { overlayRect } = this.state
     let computedStyles = styles.root
 
     if (overlayRect.top) {
       computedStyles = {
         ...computedStyles,
+        ...zIndex ? { zIndex } : {},
         top: overlayRect.top,
         left: overlayRect.left
       }

--- a/src/components/Tooltip/__tests__/Tooltip.spec.js
+++ b/src/components/Tooltip/__tests__/Tooltip.spec.js
@@ -126,4 +126,19 @@ describe('Tooltip', () => {
     expect(tooltip.state().show).toEqual(false)
   })
 
+  it('sets the zIndex correctly when a custom zIndex is specified', () => {
+    const EXPECTED_Z_INDEX = 235235
+    const tooltip = mount(
+      <Tooltip
+        target={(<button>TRIGGER</button>)}
+        zIndex={EXPECTED_Z_INDEX}
+      >
+      </Tooltip>
+    )
+
+    const trigger = tooltip.find('button').last()
+    trigger.last().simulate('click')
+
+    expect(tooltip.find('TooltipPosition > div').props().style.zIndex).toBe(EXPECTED_Z_INDEX)
+  })
 })


### PR DESCRIPTION
Currently these two components use a hardcoded value for z-index.  Sometimes when using these components you need to adjust these values.

There were a couple of options for adding this support, but I think that the way with the best backwards compatibility is to add an optional z-index prop to override the existing values.

Another possible way is to expose style overrides for the parts of these components that use z-index, but I feel like that is less friendly to the user since they must understand implementation details to adjust the z-index.