### PR TITLE
Updating TextHint accessibility

### DIFF
--- a/src/components/Forms/MaskedTextField.js
+++ b/src/components/Forms/MaskedTextField.js
@@ -276,7 +276,7 @@ class MaskedTextField extends React.Component {
           />
 
           <TextFieldHint
-            inputId={inputId}
+            inputId={`hint_${inputId}`}
             text={maskHint}
             show={!hasValue && isFocused}
             disabled={disabled}

--- a/src/components/Forms/MaskedTextField.js
+++ b/src/components/Forms/MaskedTextField.js
@@ -275,7 +275,12 @@ class MaskedTextField extends React.Component {
             snacksTheme={snacksTheme}
           />
 
-          <TextFieldHint text={maskHint} show={!hasValue && isFocused} disabled={disabled} />
+          <TextFieldHint
+            inputId={inputId}
+            text={maskHint}
+            show={!hasValue && isFocused}
+            disabled={disabled}
+          />
 
           <MaskedTextInput
             mask={mask}
@@ -285,6 +290,7 @@ class MaskedTextField extends React.Component {
             name={name}
             aria-required={required}
             aria-invalid={hasError}
+            aria-describedby={hasError ? `hint_${inputId} error_${inputId}` : `hint_${inputId}`}
             onBlur={this.handleInputBlur}
             onChange={this.handleInputChange}
             onFocus={this.handleInputFocus}

--- a/src/components/Forms/TextField.js
+++ b/src/components/Forms/TextField.js
@@ -214,14 +214,10 @@ class TextField extends React.Component {
     const snacksStyles = getSnackStyles(snacksTheme)
 
     const inputId = id
+    const errorId = `error_${inputId}`
+    const hintId = `hint_${inputId}`
     const showHintText = hintText && !hasValue && isFocused
-    let describedByIds = ''
-    if (hasError) {
-      describedByIds += `error_${inputId}`
-    }
-    if (hintText) {
-      describedByIds += ` hint_${inputId}`
-    }
+    const describedByIds = `${hasError ? errorId : ''} ${hintText ? hintId : ''}`.trim()
 
     return (
       <div
@@ -266,7 +262,7 @@ class TextField extends React.Component {
             type={type}
             aria-required={required}
             aria-invalid={hasError}
-            aria-describedby={describedByIds ? describedByIds.trim() : null}
+            aria-describedby={hasError || hintText ? describedByIds : null}
             style={[
               styles.input,
               inputStyle,

--- a/src/components/Forms/TextField.js
+++ b/src/components/Forms/TextField.js
@@ -259,7 +259,12 @@ class TextField extends React.Component {
             type={type}
             aria-required={required}
             aria-invalid={hasError}
-            aria-describedby={[hasError ? `error_${inputId}` : null, hintText ? `hint_${inputId}` : null].join(' ').trim()}
+            aria-describedby={[
+              hasError ? `error_${inputId}` : null,
+              hintText ? `hint_${inputId}` : null,
+            ]
+              .join(' ')
+              .trim()}
             style={[
               styles.input,
               inputStyle,

--- a/src/components/Forms/TextField.js
+++ b/src/components/Forms/TextField.js
@@ -263,8 +263,8 @@ class TextField extends React.Component {
               hasError ? `error_${inputId}` : null,
               hintText ? `hint_${inputId}` : null,
             ]
-              .join(' ')
-              .trim()}
+              .filter(Boolean)
+              .join(' ')}
             style={[
               styles.input,
               inputStyle,

--- a/src/components/Forms/TextField.js
+++ b/src/components/Forms/TextField.js
@@ -214,10 +214,7 @@ class TextField extends React.Component {
     const snacksStyles = getSnackStyles(snacksTheme)
 
     const inputId = id
-    const errorId = `error_${inputId}`
-    const hintId = `hint_${inputId}`
     const showHintText = hintText && !hasValue && isFocused
-    const describedByIds = `${hasError ? errorId : ''} ${hintText ? hintId : ''}`.trim()
 
     return (
       <div
@@ -262,7 +259,7 @@ class TextField extends React.Component {
             type={type}
             aria-required={required}
             aria-invalid={hasError}
-            aria-describedby={hasError || hintText ? describedByIds : null}
+            aria-describedby={[hasError ? `error_${inputId}` : null, hintText ? `hint_${inputId}` : null].join(' ').trim()}
             style={[
               styles.input,
               inputStyle,

--- a/src/components/Forms/TextField.js
+++ b/src/components/Forms/TextField.js
@@ -215,8 +215,13 @@ class TextField extends React.Component {
 
     const inputId = id
     const showHintText = hintText && !hasValue && isFocused
-    let describedIds = hasError ? `error_${inputId}` : ''
-    describedIds += hintText ? ` hint_${inputId}` : ''
+    let describedByIds = ''
+    if (hasError) {
+      describedByIds += `error_${inputId}`
+    }
+    if (hintText) {
+      describedByIds += ` hint_${inputId}`
+    }
 
     return (
       <div
@@ -261,7 +266,7 @@ class TextField extends React.Component {
             type={type}
             aria-required={required}
             aria-invalid={hasError}
-            aria-describedby={describedIds ? describedIds.trim() : null}
+            aria-describedby={describedByIds ? describedByIds.trim() : null}
             style={[
               styles.input,
               inputStyle,

--- a/src/components/Forms/TextField.js
+++ b/src/components/Forms/TextField.js
@@ -215,6 +215,8 @@ class TextField extends React.Component {
 
     const inputId = id
     const showHintText = hintText && !hasValue && isFocused
+    let describedIds = hasError ? `error_${inputId}` : ''
+    describedIds += hintText ? ` hint_${inputId}` : ''
 
     return (
       <div
@@ -238,7 +240,14 @@ class TextField extends React.Component {
             snacksTheme={snacksTheme}
           />
 
-          {hintText && <TextFieldHint text={hintText} show={showHintText} disabled={disabled} />}
+          {hintText && (
+            <TextFieldHint
+              inputId={`hint_${inputId}`}
+              text={hintText}
+              show={showHintText}
+              disabled={disabled}
+            />
+          )}
 
           <input
             value={value}
@@ -252,7 +261,7 @@ class TextField extends React.Component {
             type={type}
             aria-required={required}
             aria-invalid={hasError}
-            aria-describedby={hasError ? `error_${inputId}` : null}
+            aria-describedby={describedIds ? describedIds.trim() : null}
             style={[
               styles.input,
               inputStyle,

--- a/src/components/Forms/TextFieldHint.js
+++ b/src/components/Forms/TextFieldHint.js
@@ -12,7 +12,8 @@ const styles = {
     opacity: 0,
     transform: 'scale(1) translate(9px, 26px)',
     transformOrigin: 'left top',
-    transition: 'opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms',
+    transition:
+      'visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms',
     pointerEvents: 'none',
     zIndex: 1,
     visibility: 'hidden',
@@ -50,7 +51,7 @@ class TextFieldHint extends Component {
 
     return (
       <div
-        id={`hint_${inputId}`}
+        id={inputId}
         style={[styles.root, style, disabled && styles.disabled, show && styles.show]}
       >
         {text}

--- a/src/components/Forms/TextFieldHint.js
+++ b/src/components/Forms/TextFieldHint.js
@@ -15,9 +15,11 @@ const styles = {
     transition: 'opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms',
     pointerEvents: 'none',
     zIndex: 1,
+    visibility: 'hidden',
   },
   show: {
     opacity: 1,
+    visibility: 'visible',
   },
   disabled: {
     cursor: 'not-allowed',
@@ -35,6 +37,8 @@ class TextFieldHint extends Component {
     show: PropTypes.bool,
     /** Override styles */
     style: PropTypes.object,
+    /** A uniq id */
+    inputId: PropTypes.string,
   }
 
   static defaultProps = {
@@ -42,10 +46,13 @@ class TextFieldHint extends Component {
   }
 
   render() {
-    const { disabled, show, style, text } = this.props
+    const { disabled, show, style, text, inputId } = this.props
 
     return (
-      <div style={[styles.root, style, disabled && styles.disabled, show && styles.show]}>
+      <div
+        id={`hint_${inputId}`}
+        style={[styles.root, style, disabled && styles.disabled, show && styles.show]}
+      >
         {text}
       </div>
     )

--- a/src/components/Forms/TextFieldHint.js
+++ b/src/components/Forms/TextFieldHint.js
@@ -12,14 +12,14 @@ const styles = {
     opacity: 0,
     transform: 'scale(1) translate(9px, 26px)',
     transformOrigin: 'left top',
-    transition:
-      'visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms',
+    transition: 'visibility 0ms linear 250ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms',
     pointerEvents: 'none',
     zIndex: 1,
     visibility: 'hidden',
   },
   show: {
     opacity: 1,
+    transition: 'visibility 0ms linear 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms',
     visibility: 'visible',
   },
   disabled: {

--- a/src/components/Forms/__tests__/__snapshots__/DateField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/DateField.spec.js.snap
@@ -239,7 +239,7 @@ exports[`renders correctly 1`] = `
                           "position": "absolute",
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
-                          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "transition": "visibility 0ms linear 250ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                           "visibility": "hidden",
                           "zIndex": 1,
                         }
@@ -614,7 +614,7 @@ exports[`renders correctly with focus state 1`] = `
                           "position": "absolute",
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
-                          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "transition": "visibility 0ms linear 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                           "visibility": "visible",
                           "zIndex": 1,
                         }
@@ -1015,7 +1015,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                           "position": "absolute",
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
-                          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "transition": "visibility 0ms linear 250ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                           "visibility": "hidden",
                           "zIndex": 1,
                         }

--- a/src/components/Forms/__tests__/__snapshots__/DateField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/DateField.spec.js.snap
@@ -222,11 +222,13 @@ exports[`renders correctly 1`] = `
                   </withTheme(RadiumEnhancer)>
                   <TextFieldHint
                     disabled={false}
+                    inputId="test_id"
                     key=".1"
                     text="MM/DD/YYYY"
                   >
                     <div
                       data-radium={true}
+                      id="hint_test_id"
                       style={
                         Object {
                           "color": "#BDBDBD",
@@ -238,6 +240,7 @@ exports[`renders correctly 1`] = `
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
                           "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "visibility": "hidden",
                           "zIndex": 1,
                         }
                       }
@@ -246,6 +249,7 @@ exports[`renders correctly 1`] = `
                     </div>
                   </TextFieldHint>
                   <t
+                    aria-describedby="hint_test_id"
                     aria-invalid={false}
                     autoComplete="on"
                     defaultValue={null}
@@ -279,6 +283,7 @@ exports[`renders correctly 1`] = `
                     type="tel"
                   >
                     <input
+                      aria-describedby="hint_test_id"
                       aria-invalid={false}
                       autoComplete="on"
                       defaultValue={null}
@@ -591,12 +596,14 @@ exports[`renders correctly with focus state 1`] = `
                   </withTheme(RadiumEnhancer)>
                   <TextFieldHint
                     disabled={false}
+                    inputId="test_id"
                     key=".1"
                     show={true}
                     text="MM/DD/YYYY"
                   >
                     <div
                       data-radium={true}
+                      id="hint_test_id"
                       style={
                         Object {
                           "color": "#BDBDBD",
@@ -608,6 +615,7 @@ exports[`renders correctly with focus state 1`] = `
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
                           "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "visibility": "visible",
                           "zIndex": 1,
                         }
                       }
@@ -616,6 +624,7 @@ exports[`renders correctly with focus state 1`] = `
                     </div>
                   </TextFieldHint>
                   <t
+                    aria-describedby="hint_test_id"
                     aria-invalid={false}
                     autoComplete="on"
                     defaultValue={null}
@@ -649,6 +658,7 @@ exports[`renders correctly with focus state 1`] = `
                     type="tel"
                   >
                     <input
+                      aria-describedby="hint_test_id"
                       aria-invalid={false}
                       autoComplete="on"
                       defaultValue={null}
@@ -988,11 +998,13 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                   </withTheme(RadiumEnhancer)>
                   <TextFieldHint
                     disabled={false}
+                    inputId="test_id"
                     key=".1"
                     text="MM/DD/YYYY"
                   >
                     <div
                       data-radium={true}
+                      id="hint_test_id"
                       style={
                         Object {
                           "color": "#BDBDBD",
@@ -1004,6 +1016,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
                           "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "visibility": "hidden",
                           "zIndex": 1,
                         }
                       }
@@ -1012,6 +1025,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                     </div>
                   </TextFieldHint>
                   <t
+                    aria-describedby="hint_test_id"
                     aria-invalid={false}
                     autoComplete="on"
                     defaultValue={null}
@@ -1045,6 +1059,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                     type="tel"
                   >
                     <input
+                      aria-describedby="hint_test_id"
                       aria-invalid={false}
                       autoComplete="on"
                       defaultValue={null}

--- a/src/components/Forms/__tests__/__snapshots__/DateField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/DateField.spec.js.snap
@@ -222,7 +222,7 @@ exports[`renders correctly 1`] = `
                   </withTheme(RadiumEnhancer)>
                   <TextFieldHint
                     disabled={false}
-                    inputId="test_id"
+                    inputId="hint_test_id"
                     key=".1"
                     text="MM/DD/YYYY"
                   >
@@ -239,7 +239,7 @@ exports[`renders correctly 1`] = `
                           "position": "absolute",
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
-                          "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                           "visibility": "hidden",
                           "zIndex": 1,
                         }
@@ -596,7 +596,7 @@ exports[`renders correctly with focus state 1`] = `
                   </withTheme(RadiumEnhancer)>
                   <TextFieldHint
                     disabled={false}
-                    inputId="test_id"
+                    inputId="hint_test_id"
                     key=".1"
                     show={true}
                     text="MM/DD/YYYY"
@@ -614,7 +614,7 @@ exports[`renders correctly with focus state 1`] = `
                           "position": "absolute",
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
-                          "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                           "visibility": "visible",
                           "zIndex": 1,
                         }
@@ -998,7 +998,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                   </withTheme(RadiumEnhancer)>
                   <TextFieldHint
                     disabled={false}
-                    inputId="test_id"
+                    inputId="hint_test_id"
                     key=".1"
                     text="MM/DD/YYYY"
                   >
@@ -1015,7 +1015,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                           "position": "absolute",
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
-                          "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                           "visibility": "hidden",
                           "zIndex": 1,
                         }

--- a/src/components/Forms/__tests__/__snapshots__/Form.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/Form.spec.js.snap
@@ -52,7 +52,7 @@ exports[`renders Form with TextField correctly 1`] = `
           Email
         </label>
         <input
-          aria-describedby={null}
+          aria-describedby=""
           aria-invalid={false}
           aria-required={undefined}
           autoComplete="on"

--- a/src/components/Forms/__tests__/__snapshots__/MaskedTextField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/MaskedTextField.spec.js.snap
@@ -210,7 +210,7 @@ exports[`renders correctly 1`] = `
                 </withTheme(RadiumEnhancer)>
                 <TextFieldHint
                   disabled={false}
-                  inputId="test_id"
+                  inputId="hint_test_id"
                   key=".1"
                   text="555-55-5555"
                 >
@@ -227,7 +227,7 @@ exports[`renders correctly 1`] = `
                         "position": "absolute",
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
-                        "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                         "visibility": "hidden",
                         "zIndex": 1,
                       }
@@ -569,7 +569,7 @@ exports[`renders correctly with focus state 1`] = `
                 </withTheme(RadiumEnhancer)>
                 <TextFieldHint
                   disabled={false}
-                  inputId="test_id"
+                  inputId="hint_test_id"
                   key=".1"
                   show={true}
                   text="555-55-5555"
@@ -587,7 +587,7 @@ exports[`renders correctly with focus state 1`] = `
                         "position": "absolute",
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
-                        "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                         "visibility": "visible",
                         "zIndex": 1,
                       }
@@ -942,7 +942,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                 </withTheme(RadiumEnhancer)>
                 <TextFieldHint
                   disabled={false}
-                  inputId="test_id"
+                  inputId="hint_test_id"
                   key=".1"
                   text="555-55-5555"
                 >
@@ -959,7 +959,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                         "position": "absolute",
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
-                        "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                         "visibility": "hidden",
                         "zIndex": 1,
                       }

--- a/src/components/Forms/__tests__/__snapshots__/MaskedTextField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/MaskedTextField.spec.js.snap
@@ -227,7 +227,7 @@ exports[`renders correctly 1`] = `
                         "position": "absolute",
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
-                        "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "transition": "visibility 0ms linear 250ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                         "visibility": "hidden",
                         "zIndex": 1,
                       }
@@ -587,7 +587,7 @@ exports[`renders correctly with focus state 1`] = `
                         "position": "absolute",
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
-                        "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "transition": "visibility 0ms linear 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                         "visibility": "visible",
                         "zIndex": 1,
                       }
@@ -959,7 +959,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                         "position": "absolute",
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
-                        "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "transition": "visibility 0ms linear 250ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                         "visibility": "hidden",
                         "zIndex": 1,
                       }

--- a/src/components/Forms/__tests__/__snapshots__/MaskedTextField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/MaskedTextField.spec.js.snap
@@ -210,11 +210,13 @@ exports[`renders correctly 1`] = `
                 </withTheme(RadiumEnhancer)>
                 <TextFieldHint
                   disabled={false}
+                  inputId="test_id"
                   key=".1"
                   text="555-55-5555"
                 >
                   <div
                     data-radium={true}
+                    id="hint_test_id"
                     style={
                       Object {
                         "color": "#BDBDBD",
@@ -226,6 +228,7 @@ exports[`renders correctly 1`] = `
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
                         "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "visibility": "hidden",
                         "zIndex": 1,
                       }
                     }
@@ -234,6 +237,7 @@ exports[`renders correctly 1`] = `
                   </div>
                 </TextFieldHint>
                 <t
+                  aria-describedby="hint_test_id"
                   aria-invalid={false}
                   autoComplete="on"
                   defaultValue={null}
@@ -266,6 +270,7 @@ exports[`renders correctly 1`] = `
                   render={[Function]}
                 >
                   <input
+                    aria-describedby="hint_test_id"
                     aria-invalid={false}
                     autoComplete="on"
                     defaultValue={null}
@@ -564,12 +569,14 @@ exports[`renders correctly with focus state 1`] = `
                 </withTheme(RadiumEnhancer)>
                 <TextFieldHint
                   disabled={false}
+                  inputId="test_id"
                   key=".1"
                   show={true}
                   text="555-55-5555"
                 >
                   <div
                     data-radium={true}
+                    id="hint_test_id"
                     style={
                       Object {
                         "color": "#BDBDBD",
@@ -581,6 +588,7 @@ exports[`renders correctly with focus state 1`] = `
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
                         "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "visibility": "visible",
                         "zIndex": 1,
                       }
                     }
@@ -589,6 +597,7 @@ exports[`renders correctly with focus state 1`] = `
                   </div>
                 </TextFieldHint>
                 <t
+                  aria-describedby="hint_test_id"
                   aria-invalid={false}
                   autoComplete="on"
                   defaultValue={null}
@@ -621,6 +630,7 @@ exports[`renders correctly with focus state 1`] = `
                   render={[Function]}
                 >
                   <input
+                    aria-describedby="hint_test_id"
                     aria-invalid={false}
                     autoComplete="on"
                     defaultValue={null}
@@ -932,11 +942,13 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                 </withTheme(RadiumEnhancer)>
                 <TextFieldHint
                   disabled={false}
+                  inputId="test_id"
                   key=".1"
                   text="555-55-5555"
                 >
                   <div
                     data-radium={true}
+                    id="hint_test_id"
                     style={
                       Object {
                         "color": "#BDBDBD",
@@ -948,6 +960,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
                         "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "visibility": "hidden",
                         "zIndex": 1,
                       }
                     }
@@ -956,6 +969,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                   </div>
                 </TextFieldHint>
                 <t
+                  aria-describedby="hint_test_id"
                   aria-invalid={false}
                   autoComplete="on"
                   defaultValue={null}
@@ -988,6 +1002,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                   render={[Function]}
                 >
                   <input
+                    aria-describedby="hint_test_id"
                     aria-invalid={false}
                     autoComplete="on"
                     defaultValue={null}

--- a/src/components/Forms/__tests__/__snapshots__/PhoneNumberField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/PhoneNumberField.spec.js.snap
@@ -231,11 +231,13 @@ exports[`renders correctly 1`] = `
                   </withTheme(RadiumEnhancer)>
                   <TextFieldHint
                     disabled={false}
+                    inputId="test_id"
                     key=".1"
                     text="(555) 555-5555"
                   >
                     <div
                       data-radium={true}
+                      id="hint_test_id"
                       style={
                         Object {
                           "color": "#BDBDBD",
@@ -247,6 +249,7 @@ exports[`renders correctly 1`] = `
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
                           "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "visibility": "hidden",
                           "zIndex": 1,
                         }
                       }
@@ -255,6 +258,7 @@ exports[`renders correctly 1`] = `
                     </div>
                   </TextFieldHint>
                   <t
+                    aria-describedby="hint_test_id"
                     aria-invalid={false}
                     autoComplete="on"
                     defaultValue={null}
@@ -291,6 +295,7 @@ exports[`renders correctly 1`] = `
                     type="tel"
                   >
                     <input
+                      aria-describedby="hint_test_id"
                       aria-invalid={false}
                       autoComplete="on"
                       defaultValue={null}
@@ -612,12 +617,14 @@ exports[`renders correctly with focus state 1`] = `
                   </withTheme(RadiumEnhancer)>
                   <TextFieldHint
                     disabled={false}
+                    inputId="test_id"
                     key=".1"
                     show={true}
                     text="(555) 555-5555"
                   >
                     <div
                       data-radium={true}
+                      id="hint_test_id"
                       style={
                         Object {
                           "color": "#BDBDBD",
@@ -629,6 +636,7 @@ exports[`renders correctly with focus state 1`] = `
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
                           "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "visibility": "visible",
                           "zIndex": 1,
                         }
                       }
@@ -637,6 +645,7 @@ exports[`renders correctly with focus state 1`] = `
                     </div>
                   </TextFieldHint>
                   <t
+                    aria-describedby="hint_test_id"
                     aria-invalid={false}
                     autoComplete="on"
                     defaultValue={null}
@@ -673,6 +682,7 @@ exports[`renders correctly with focus state 1`] = `
                     type="tel"
                   >
                     <input
+                      aria-describedby="hint_test_id"
                       aria-invalid={false}
                       autoComplete="on"
                       defaultValue={null}
@@ -1021,11 +1031,13 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                   </withTheme(RadiumEnhancer)>
                   <TextFieldHint
                     disabled={false}
+                    inputId="test_id"
                     key=".1"
                     text="(555) 555-5555"
                   >
                     <div
                       data-radium={true}
+                      id="hint_test_id"
                       style={
                         Object {
                           "color": "#BDBDBD",
@@ -1037,6 +1049,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
                           "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "visibility": "hidden",
                           "zIndex": 1,
                         }
                       }
@@ -1045,6 +1058,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                     </div>
                   </TextFieldHint>
                   <t
+                    aria-describedby="hint_test_id"
                     aria-invalid={false}
                     autoComplete="on"
                     defaultValue={null}
@@ -1081,6 +1095,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                     type="tel"
                   >
                     <input
+                      aria-describedby="hint_test_id"
                       aria-invalid={false}
                       autoComplete="on"
                       defaultValue={null}

--- a/src/components/Forms/__tests__/__snapshots__/PhoneNumberField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/PhoneNumberField.spec.js.snap
@@ -248,7 +248,7 @@ exports[`renders correctly 1`] = `
                           "position": "absolute",
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
-                          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "transition": "visibility 0ms linear 250ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                           "visibility": "hidden",
                           "zIndex": 1,
                         }
@@ -635,7 +635,7 @@ exports[`renders correctly with focus state 1`] = `
                           "position": "absolute",
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
-                          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "transition": "visibility 0ms linear 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                           "visibility": "visible",
                           "zIndex": 1,
                         }
@@ -1048,7 +1048,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                           "position": "absolute",
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
-                          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "transition": "visibility 0ms linear 250ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                           "visibility": "hidden",
                           "zIndex": 1,
                         }

--- a/src/components/Forms/__tests__/__snapshots__/PhoneNumberField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/PhoneNumberField.spec.js.snap
@@ -231,7 +231,7 @@ exports[`renders correctly 1`] = `
                   </withTheme(RadiumEnhancer)>
                   <TextFieldHint
                     disabled={false}
-                    inputId="test_id"
+                    inputId="hint_test_id"
                     key=".1"
                     text="(555) 555-5555"
                   >
@@ -248,7 +248,7 @@ exports[`renders correctly 1`] = `
                           "position": "absolute",
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
-                          "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                           "visibility": "hidden",
                           "zIndex": 1,
                         }
@@ -617,7 +617,7 @@ exports[`renders correctly with focus state 1`] = `
                   </withTheme(RadiumEnhancer)>
                   <TextFieldHint
                     disabled={false}
-                    inputId="test_id"
+                    inputId="hint_test_id"
                     key=".1"
                     show={true}
                     text="(555) 555-5555"
@@ -635,7 +635,7 @@ exports[`renders correctly with focus state 1`] = `
                           "position": "absolute",
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
-                          "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                           "visibility": "visible",
                           "zIndex": 1,
                         }
@@ -1031,7 +1031,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                   </withTheme(RadiumEnhancer)>
                   <TextFieldHint
                     disabled={false}
-                    inputId="test_id"
+                    inputId="hint_test_id"
                     key=".1"
                     text="(555) 555-5555"
                   >
@@ -1048,7 +1048,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                           "position": "absolute",
                           "transform": "scale(1) translate(9px, 26px)",
                           "transformOrigin": "left top",
-                          "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                           "visibility": "hidden",
                           "zIndex": 1,
                         }

--- a/src/components/Forms/__tests__/__snapshots__/Select.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/Select.spec.js.snap
@@ -121,6 +121,7 @@ exports[`renders Select correctly 1`] = `
                 >
                   <div
                     data-radium={true}
+                    id="hint_undefined"
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     style={
@@ -136,6 +137,7 @@ exports[`renders Select correctly 1`] = `
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
                         "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "visibility": "hidden",
                         "zIndex": 1,
                       }
                     }
@@ -498,6 +500,7 @@ exports[`renders Select w/ server error correctly 1`] = `
                 >
                   <div
                     data-radium={true}
+                    id="hint_undefined"
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     style={
@@ -513,6 +516,7 @@ exports[`renders Select w/ server error correctly 1`] = `
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
                         "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "visibility": "hidden",
                         "zIndex": 1,
                       }
                     }
@@ -877,6 +881,7 @@ exports[`renders disabled Select correctly 1`] = `
                 >
                   <div
                     data-radium={true}
+                    id="hint_undefined"
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     style={
@@ -892,6 +897,7 @@ exports[`renders disabled Select correctly 1`] = `
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
                         "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "visibility": "hidden",
                         "zIndex": 1,
                       }
                     }
@@ -1254,6 +1260,7 @@ exports[`renders invalid Select correctly 1`] = `
                 >
                   <div
                     data-radium={true}
+                    id="hint_undefined"
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     style={
@@ -1269,6 +1276,7 @@ exports[`renders invalid Select correctly 1`] = `
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
                         "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "visibility": "hidden",
                         "zIndex": 1,
                       }
                     }
@@ -1630,6 +1638,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
               >
                 <div
                   data-radium={true}
+                  id="hint_undefined"
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   style={
@@ -1645,6 +1654,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                       "transform": "scale(1) translate(9px, 26px)",
                       "transformOrigin": "left top",
                       "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                      "visibility": "hidden",
                       "zIndex": 1,
                     }
                   }

--- a/src/components/Forms/__tests__/__snapshots__/Select.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/Select.spec.js.snap
@@ -136,7 +136,7 @@ exports[`renders Select correctly 1`] = `
                         "top": 0,
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
-                        "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "transition": "visibility 0ms linear 250ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                         "visibility": "hidden",
                         "zIndex": 1,
                       }
@@ -515,7 +515,7 @@ exports[`renders Select w/ server error correctly 1`] = `
                         "top": 0,
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
-                        "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "transition": "visibility 0ms linear 250ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                         "visibility": "hidden",
                         "zIndex": 1,
                       }
@@ -896,7 +896,7 @@ exports[`renders disabled Select correctly 1`] = `
                         "top": 0,
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
-                        "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "transition": "visibility 0ms linear 250ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                         "visibility": "hidden",
                         "zIndex": 1,
                       }
@@ -1275,7 +1275,7 @@ exports[`renders invalid Select correctly 1`] = `
                         "top": 0,
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
-                        "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "transition": "visibility 0ms linear 250ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                         "visibility": "hidden",
                         "zIndex": 1,
                       }
@@ -1653,7 +1653,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                       "top": 0,
                       "transform": "scale(1) translate(9px, 26px)",
                       "transformOrigin": "left top",
-                      "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                      "transition": "visibility 0ms linear 250ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                       "visibility": "hidden",
                       "zIndex": 1,
                     }

--- a/src/components/Forms/__tests__/__snapshots__/Select.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/Select.spec.js.snap
@@ -121,7 +121,7 @@ exports[`renders Select correctly 1`] = `
                 >
                   <div
                     data-radium={true}
-                    id="hint_undefined"
+                    id={undefined}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     style={
@@ -136,7 +136,7 @@ exports[`renders Select correctly 1`] = `
                         "top": 0,
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
-                        "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                         "visibility": "hidden",
                         "zIndex": 1,
                       }
@@ -500,7 +500,7 @@ exports[`renders Select w/ server error correctly 1`] = `
                 >
                   <div
                     data-radium={true}
-                    id="hint_undefined"
+                    id={undefined}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     style={
@@ -515,7 +515,7 @@ exports[`renders Select w/ server error correctly 1`] = `
                         "top": 0,
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
-                        "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                         "visibility": "hidden",
                         "zIndex": 1,
                       }
@@ -881,7 +881,7 @@ exports[`renders disabled Select correctly 1`] = `
                 >
                   <div
                     data-radium={true}
-                    id="hint_undefined"
+                    id={undefined}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     style={
@@ -896,7 +896,7 @@ exports[`renders disabled Select correctly 1`] = `
                         "top": 0,
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
-                        "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                         "visibility": "hidden",
                         "zIndex": 1,
                       }
@@ -1260,7 +1260,7 @@ exports[`renders invalid Select correctly 1`] = `
                 >
                   <div
                     data-radium={true}
-                    id="hint_undefined"
+                    id={undefined}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     style={
@@ -1275,7 +1275,7 @@ exports[`renders invalid Select correctly 1`] = `
                         "top": 0,
                         "transform": "scale(1) translate(9px, 26px)",
                         "transformOrigin": "left top",
-                        "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                         "visibility": "hidden",
                         "zIndex": 1,
                       }
@@ -1638,7 +1638,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
               >
                 <div
                   data-radium={true}
-                  id="hint_undefined"
+                  id={undefined}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   style={
@@ -1653,7 +1653,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                       "top": 0,
                       "transform": "scale(1) translate(9px, 26px)",
                       "transformOrigin": "left top",
-                      "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                      "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                       "visibility": "hidden",
                       "zIndex": 1,
                     }

--- a/src/components/Forms/__tests__/__snapshots__/TextField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/TextField.spec.js.snap
@@ -51,6 +51,7 @@ exports[`renders TextField correctly 1`] = `
         </label>
         <div
           data-radium={true}
+          id="hint_undefined"
           style={
             Object {
               "color": "#BDBDBD",
@@ -62,6 +63,7 @@ exports[`renders TextField correctly 1`] = `
               "transform": "scale(1) translate(9px, 26px)",
               "transformOrigin": "left top",
               "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "visibility": "hidden",
               "zIndex": 1,
             }
           }
@@ -192,6 +194,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
         </label>
         <div
           data-radium={true}
+          id="hint_undefined"
           style={
             Object {
               "color": "#BDBDBD",
@@ -203,6 +206,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
               "transform": "scale(1) translate(9px, 26px)",
               "transformOrigin": "left top",
               "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "visibility": "hidden",
               "zIndex": 1,
             }
           }

--- a/src/components/Forms/__tests__/__snapshots__/TextField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/TextField.spec.js.snap
@@ -62,7 +62,7 @@ exports[`renders TextField correctly 1`] = `
               "position": "absolute",
               "transform": "scale(1) translate(9px, 26px)",
               "transformOrigin": "left top",
-              "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "transition": "visibility 0ms linear 250ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
               "visibility": "hidden",
               "zIndex": 1,
             }
@@ -205,7 +205,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
               "position": "absolute",
               "transform": "scale(1) translate(9px, 26px)",
               "transformOrigin": "left top",
-              "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "transition": "visibility 0ms linear 250ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
               "visibility": "hidden",
               "zIndex": 1,
             }

--- a/src/components/Forms/__tests__/__snapshots__/TextField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/TextField.spec.js.snap
@@ -51,7 +51,7 @@ exports[`renders TextField correctly 1`] = `
         </label>
         <div
           data-radium={true}
-          id="hint_undefined"
+          id="hint_test_id"
           style={
             Object {
               "color": "#BDBDBD",
@@ -62,7 +62,7 @@ exports[`renders TextField correctly 1`] = `
               "position": "absolute",
               "transform": "scale(1) translate(9px, 26px)",
               "transformOrigin": "left top",
-              "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
               "visibility": "hidden",
               "zIndex": 1,
             }
@@ -71,7 +71,7 @@ exports[`renders TextField correctly 1`] = `
           Enter your email address
         </div>
         <input
-          aria-describedby={null}
+          aria-describedby="hint_test_id"
           aria-invalid={false}
           aria-required={undefined}
           autoComplete="on"
@@ -194,7 +194,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
         </label>
         <div
           data-radium={true}
-          id="hint_undefined"
+          id="hint_test_id"
           style={
             Object {
               "color": "#BDBDBD",
@@ -205,7 +205,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
               "position": "absolute",
               "transform": "scale(1) translate(9px, 26px)",
               "transformOrigin": "left top",
-              "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
               "visibility": "hidden",
               "zIndex": 1,
             }
@@ -214,7 +214,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
           Enter your email address
         </div>
         <input
-          aria-describedby={null}
+          aria-describedby="hint_test_id"
           aria-invalid={false}
           aria-required={undefined}
           autoComplete="on"

--- a/src/components/Forms/__tests__/__snapshots__/TextFieldHint.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/TextFieldHint.spec.js.snap
@@ -7,6 +7,7 @@ exports[`renders TextFieldHint correctly 1`] = `
   <div>
     <div
       data-radium={true}
+      id="hint_undefined"
       style={
         Object {
           "color": "#BDBDBD",
@@ -18,6 +19,7 @@ exports[`renders TextFieldHint correctly 1`] = `
           "transform": "scale(1) translate(9px, 26px)",
           "transformOrigin": "left top",
           "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+          "visibility": "visible",
           "zIndex": 1,
         }
       }
@@ -42,6 +44,7 @@ exports[`renders TextFieldHint when disabled 1`] = `
   <div>
     <div
       data-radium={true}
+      id="hint_undefined"
       style={
         Object {
           "color": "#BDBDBD",
@@ -53,6 +56,7 @@ exports[`renders TextFieldHint when disabled 1`] = `
           "transform": "scale(1) translate(9px, 26px)",
           "transformOrigin": "left top",
           "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+          "visibility": "visible",
           "zIndex": 1,
         }
       }
@@ -77,6 +81,7 @@ exports[`renders TextFieldHint when show is false 1`] = `
   <div>
     <div
       data-radium={true}
+      id="hint_undefined"
       style={
         Object {
           "color": "#BDBDBD",
@@ -88,6 +93,7 @@ exports[`renders TextFieldHint when show is false 1`] = `
           "transform": "scale(1) translate(9px, 26px)",
           "transformOrigin": "left top",
           "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+          "visibility": "hidden",
           "zIndex": 1,
         }
       }

--- a/src/components/Forms/__tests__/__snapshots__/TextFieldHint.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/TextFieldHint.spec.js.snap
@@ -7,7 +7,7 @@ exports[`renders TextFieldHint correctly 1`] = `
   <div>
     <div
       data-radium={true}
-      id="hint_undefined"
+      id={undefined}
       style={
         Object {
           "color": "#BDBDBD",
@@ -18,7 +18,7 @@ exports[`renders TextFieldHint correctly 1`] = `
           "position": "absolute",
           "transform": "scale(1) translate(9px, 26px)",
           "transformOrigin": "left top",
-          "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           "visibility": "visible",
           "zIndex": 1,
         }
@@ -44,7 +44,7 @@ exports[`renders TextFieldHint when disabled 1`] = `
   <div>
     <div
       data-radium={true}
-      id="hint_undefined"
+      id={undefined}
       style={
         Object {
           "color": "#BDBDBD",
@@ -55,7 +55,7 @@ exports[`renders TextFieldHint when disabled 1`] = `
           "position": "absolute",
           "transform": "scale(1) translate(9px, 26px)",
           "transformOrigin": "left top",
-          "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           "visibility": "visible",
           "zIndex": 1,
         }
@@ -81,7 +81,7 @@ exports[`renders TextFieldHint when show is false 1`] = `
   <div>
     <div
       data-radium={true}
-      id="hint_undefined"
+      id={undefined}
       style={
         Object {
           "color": "#BDBDBD",
@@ -92,7 +92,7 @@ exports[`renders TextFieldHint when show is false 1`] = `
           "position": "absolute",
           "transform": "scale(1) translate(9px, 26px)",
           "transformOrigin": "left top",
-          "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           "visibility": "hidden",
           "zIndex": 1,
         }

--- a/src/components/Forms/__tests__/__snapshots__/TextFieldHint.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/TextFieldHint.spec.js.snap
@@ -18,7 +18,7 @@ exports[`renders TextFieldHint correctly 1`] = `
           "position": "absolute",
           "transform": "scale(1) translate(9px, 26px)",
           "transformOrigin": "left top",
-          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+          "transition": "visibility 0ms linear 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           "visibility": "visible",
           "zIndex": 1,
         }
@@ -55,7 +55,7 @@ exports[`renders TextFieldHint when disabled 1`] = `
           "position": "absolute",
           "transform": "scale(1) translate(9px, 26px)",
           "transformOrigin": "left top",
-          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+          "transition": "visibility 0ms linear 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           "visibility": "visible",
           "zIndex": 1,
         }
@@ -92,7 +92,7 @@ exports[`renders TextFieldHint when show is false 1`] = `
           "position": "absolute",
           "transform": "scale(1) translate(9px, 26px)",
           "transformOrigin": "left top",
-          "transition": "visibility 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+          "transition": "visibility 0ms linear 250ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
           "visibility": "hidden",
           "zIndex": 1,
         }

--- a/src/components/Forms/docs/DateField.md
+++ b/src/components/Forms/docs/DateField.md
@@ -1,0 +1,14 @@
+DateField Example:
+```js
+<div style={{ marginBottom: 10 }}>
+  <DateField
+    name='dob'
+    type='text'
+    floatingLabelText='Date of birth'
+    required
+    halfWidth
+    id="dob"
+    validationErrorText="Please enter date of birth"
+  />
+</div>
+```


### PR DESCRIPTION
### Context (Links to Quips/Jira)
https://instacart.atlassian.net/browse/CS-7397
https://instacart.atlassian.net/browse/CS-7398


### Problem
Text hints for `MaskedTextField` are not accessibility compliant:
- Text hint was able to receive focus when not visible on screen
- Text hint was not associated to relative field
- Validation error was not associated to relative field

### Solution
- Added `visible: hidden / visible` css to TextFieldHint
- Added `aria-describedby` to `MaskedTextField`. Passing hint and validation error input id