### PR TITLE
Add propTypes to DateField

### DIFF
--- a/src/components/Forms/DateField.js
+++ b/src/components/Forms/DateField.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import createAutoCorrectedDatePipe from 'text-mask-addons/dist/createAutoCorrectedDatePipe'
-import MaskedTextField from './MaskedTextField'
+import MaskedTextField, { propTypes as maskedTextFieldPropTypes } from './MaskedTextField'
+import { omit } from 'underscore'
 
 const mask = [/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]
 const hint = 'MM/DD/YYYY'
@@ -8,8 +9,10 @@ const pipe = createAutoCorrectedDatePipe('mm/dd/yyyy')
 
 const getValue = value => value
 
+export const propTypes = omit(maskedTextFieldPropTypes, 'type', 'mask', 'maskHint', 'pipe', 'getValue', 'ref')
+
 class DateField extends React.Component {
-  static propTypes = {}
+  static propTypes = propTypes
 
   static defaultProps = {}
 

--- a/src/components/Forms/DateField.js
+++ b/src/components/Forms/DateField.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import createAutoCorrectedDatePipe from 'text-mask-addons/dist/createAutoCorrectedDatePipe'
-import { omit } from 'underscore'
-import MaskedTextField, { propTypes as maskedTextFieldPropTypes } from './MaskedTextField'
+import omit from '../../utils/omit'
+import MaskedTextField, { maskedTextFieldPropTypes } from './MaskedTextField'
 
 const mask = [/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]
 const hint = 'MM/DD/YYYY'
@@ -9,7 +9,7 @@ const pipe = createAutoCorrectedDatePipe('mm/dd/yyyy')
 
 const getValue = value => value
 
-export const propTypes = omit(
+export const dateFieldPropTypes = omit(
   maskedTextFieldPropTypes,
   'type',
   'mask',
@@ -20,7 +20,7 @@ export const propTypes = omit(
 )
 
 class DateField extends React.Component {
-  static propTypes = propTypes
+  static propTypes = dateFieldPropTypes
 
   static defaultProps = {}
 

--- a/src/components/Forms/DateField.js
+++ b/src/components/Forms/DateField.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import createAutoCorrectedDatePipe from 'text-mask-addons/dist/createAutoCorrectedDatePipe'
-import MaskedTextField, { propTypes as maskedTextFieldPropTypes } from './MaskedTextField'
 import { omit } from 'underscore'
+import MaskedTextField, { propTypes as maskedTextFieldPropTypes } from './MaskedTextField'
 
 const mask = [/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]
 const hint = 'MM/DD/YYYY'
@@ -9,7 +9,15 @@ const pipe = createAutoCorrectedDatePipe('mm/dd/yyyy')
 
 const getValue = value => value
 
-export const propTypes = omit(maskedTextFieldPropTypes, 'type', 'mask', 'maskHint', 'pipe', 'getValue', 'ref')
+export const propTypes = omit(
+  maskedTextFieldPropTypes,
+  'type',
+  'mask',
+  'maskHint',
+  'pipe',
+  'getValue',
+  'ref'
+)
 
 class DateField extends React.Component {
   static propTypes = propTypes

--- a/src/components/Forms/MaskedTextField.js
+++ b/src/components/Forms/MaskedTextField.js
@@ -91,7 +91,7 @@ const getInputSyles = ({ props, theme, isFocused }) => {
   }
 }
 
-export const propTypes = {
+export const maskedTextFieldPropTypes = {
   /** Name of the field */
   name: PropTypes.string.isRequired,
   /** Transforms the raw value from the input
@@ -164,7 +164,7 @@ export const propTypes = {
 @FormComponent
 @Radium
 class MaskedTextField extends React.Component {
-  static propTypes = propTypes
+  static propTypes = maskedTextFieldPropTypes
 
   static defaultProps = {
     autoComplete: 'on',

--- a/src/components/Forms/MaskedTextField.js
+++ b/src/components/Forms/MaskedTextField.js
@@ -91,78 +91,80 @@ const getInputSyles = ({ props, theme, isFocused }) => {
   }
 }
 
+export const propTypes = {
+  /** Name of the field */
+  name: PropTypes.string.isRequired,
+  /** Transforms the raw value from the input
+   *
+   * @example strips slashes from a phone number
+   *   (value) => value.replace(NON_DIGIT_REGEX, '')
+   * @param {string} value
+   * @returns {string}
+   */
+  getValue: PropTypes.func.isRequired,
+  /** The mask */
+  mask: PropTypes.array.isRequired,
+  /** The pipe mask */
+  pipe: PropTypes.func,
+  /** The mask hint */
+  maskHint: PropTypes.string.isRequired,
+  /** The type of the input */
+  type: PropTypes.string.isRequired,
+  /** HTML autocomplete attribute */
+  autoComplete: PropTypes.string,
+  /** DefaultValue for non controlled component */
+  defaultValue: PropTypes.any,
+  /** Disable the text field */
+  disabled: PropTypes.bool,
+  /** Text of label that will animate when TextField is focused */
+  floatingLabelText: PropTypes.string,
+  /** Sets width to 100% */
+  fullWidth: PropTypes.bool,
+  /** Sets width to 162px */
+  halfWidth: PropTypes.bool,
+  /** FormComponent error for validation */
+  hasError: PropTypes.bool,
+  /** Helper text will show up in bottom right corner below TextField */
+  helperText: PropTypes.string,
+  /** Uniq id for input */
+  id: PropTypes.string,
+  /** Style for input */
+  inputStyle: PropTypes.object,
+  /** Set by FormComponent by default.   */
+  isValid: PropTypes.bool,
+  /** onFocus callback */
+  onFocus: PropTypes.func,
+  /** onChange callback
+   *
+   * @param {SyntheticEvent} event The react `SyntheticEvent`
+   * @param {String} value The value from the input with `(`, `)`, space, and `-` characters removed
+   * @param {String} rawValue The raw value from the input
+   */
+
+  onChange: PropTypes.func,
+  /** onBlur callback */
+  onBlur: PropTypes.func,
+  /** onKeyDown callback */
+  onKeyDown: PropTypes.func,
+  /** Mark the field as required.  */
+  required: PropTypes.bool,
+  /** Error from server to show ServerError message */
+  serverError: PropTypes.string,
+  /** Wrapper styles */
+  style: PropTypes.object,
+  /** Text to show for validation error  */
+  validationErrorText: PropTypes.string,
+  /** Value will make TextField a controlled component  */
+  value: PropTypes.string,
+  /** Snacks theme attributes provided by `Themer` */
+  snacksTheme: themePropTypes,
+}
+
 @withTheme
 @FormComponent
 @Radium
 class MaskedTextField extends React.Component {
-  static propTypes = {
-    /** Name of the field */
-    name: PropTypes.string.isRequired,
-    /** Transforms the raw value from the input
-     *
-     * @example strips slashes from a phone number
-     *   (value) => value.replace(NON_DIGIT_REGEX, '')
-     * @param {string} value
-     * @returns {string}
-     */
-    getValue: PropTypes.func.isRequired,
-    /** The mask */
-    mask: PropTypes.array.isRequired,
-    /** The pipe mask */
-    pipe: PropTypes.func,
-    /** The mask hint */
-    maskHint: PropTypes.string.isRequired,
-    /** The type of the input */
-    type: PropTypes.string.isRequired,
-    /** HTML autocomplete attribute */
-    autoComplete: PropTypes.string,
-    /** DefaultValue for non controlled component */
-    defaultValue: PropTypes.any,
-    /** Disable the text field */
-    disabled: PropTypes.bool,
-    /** Text of label that will animate when TextField is focused */
-    floatingLabelText: PropTypes.string,
-    /** Sets width to 100% */
-    fullWidth: PropTypes.bool,
-    /** Sets width to 162px */
-    halfWidth: PropTypes.bool,
-    /** FormComponent error for validation */
-    hasError: PropTypes.bool,
-    /** Helper text will show up in bottom right corner below TextField */
-    helperText: PropTypes.string,
-    /** Uniq id for input */
-    id: PropTypes.string,
-    /** Style for input */
-    inputStyle: PropTypes.object,
-    /** Set by FormComponent by default.   */
-    isValid: PropTypes.bool,
-    /** onFocus callback */
-    onFocus: PropTypes.func,
-    /** onChange callback
-     *
-     * @param {SyntheticEvent} event The react `SyntheticEvent`
-     * @param {String} value The value from the input with `(`, `)`, space, and `-` characters removed
-     * @param {String} rawValue The raw value from the input
-     */
-
-    onChange: PropTypes.func,
-    /** onBlur callback */
-    onBlur: PropTypes.func,
-    /** onKeyDown callback */
-    onKeyDown: PropTypes.func,
-    /** Mark the field as required.  */
-    required: PropTypes.bool,
-    /** Error from server to show ServerError message */
-    serverError: PropTypes.string,
-    /** Wrapper styles */
-    style: PropTypes.object,
-    /** Text to show for validation error  */
-    validationErrorText: PropTypes.string,
-    /** Value will make TextField a controlled component  */
-    value: PropTypes.string,
-    /** Snacks theme attributes provided by `Themer` */
-    snacksTheme: themePropTypes,
-  }
+  static propTypes = propTypes
 
   static defaultProps = {
     autoComplete: 'on',

--- a/src/utils/__tests__/omit.spec.js
+++ b/src/utils/__tests__/omit.spec.js
@@ -1,0 +1,48 @@
+import omit from '../omit'
+
+it('omits keys', () => {
+  const objA = {
+    key1: 'a',
+    key2: 'b',
+    key3: 'c',
+    key4: 'd'
+  }
+
+  const objB = omit(objA, 'key1', 'key4')
+
+  expect(objB).toEqual({
+    key2: 'b',
+    key3: 'c'
+  })
+})
+
+it('does not blow up on keys that do not exist', () => {
+  const objA = {
+    key1: 'a',
+    key2: 'b',
+    key3: 'c',
+    key4: 'd'
+  }
+
+  const objB = omit(objA, 'key8', 'key20', 'key3', 'key1')
+
+  expect(objB).toEqual({
+    key2: 'b',
+    key4: 'd'
+  })
+})
+
+it('returns a new reference', () => {
+  const objA = {
+    key1: 'a',
+    key2: 'b',
+    key3: 'c',
+    key4: 'd'
+  }
+
+  const objB = omit(objA)
+
+  // should be equal, but not the same ref
+  expect(objA).toEqual(objB)
+  expect(objA).not.toBe(objB)
+})

--- a/src/utils/omit.js
+++ b/src/utils/omit.js
@@ -1,0 +1,5 @@
+export default function omit(obj, ...blacklistedKeys) {
+  return Object.entries(obj)
+    .filter(([key]) => !blacklistedKeys.includes(key))
+    .reduce((newObj, [key, val]) => Object.assign(newObj, { [key]: val }), {})
+}


### PR DESCRIPTION
The propTypes of DateField are a subset of the propTypes of MaskedTextField. This PR adds the proptypes so they appear in the styleguide for DateField.