### PR TITLE
Add elementAttributes to TextField

### DIFF
--- a/src/components/Forms/TextField.js
+++ b/src/components/Forms/TextField.js
@@ -123,6 +123,8 @@ class TextField extends React.Component {
     value: PropTypes.string,
     /** Snacks theme attributes provided by `Themer` */
     snacksTheme: themePropTypes,
+     /** Any additonal props to add to the element (e.g. data attributes). */
+    elementAttributes: PropTypes.object,
   }
 
   static defaultProps = {
@@ -207,6 +209,7 @@ class TextField extends React.Component {
       helperText,
       autoComplete,
       snacksTheme,
+      elementAttributes,
     } = this.props
 
     const { hasValue, isFocused } = this.state
@@ -228,15 +231,17 @@ class TextField extends React.Component {
         {serverError && !disabled && !isValid && <ServerError text={serverError} />}
 
         <div style={styles.inputContainer}>
-          <FloatingLabel
-            text={floatingLabelText}
-            float={isFocused || hasValue}
-            disabled={disabled}
-            isActive={isFocused}
-            hasError={hasError}
-            htmlFor={inputId}
-            snacksTheme={snacksTheme}
-          />
+          {floatingLabelText && (
+            <FloatingLabel
+              text={floatingLabelText}
+              float={isFocused || hasValue}
+              disabled={disabled}
+              isActive={isFocused}
+              hasError={hasError}
+              htmlFor={inputId}
+              snacksTheme={snacksTheme}
+            />
+          )}
 
           {hintText && (
             <TextFieldHint
@@ -278,6 +283,7 @@ class TextField extends React.Component {
             onKeyDown={this.handleKeyDown}
             autoComplete={autoComplete}
             placeholder=""
+            { ...elementAttributes }
           />
         </div>
 

--- a/src/components/Forms/TextField.js
+++ b/src/components/Forms/TextField.js
@@ -123,7 +123,7 @@ class TextField extends React.Component {
     value: PropTypes.string,
     /** Snacks theme attributes provided by `Themer` */
     snacksTheme: themePropTypes,
-     /** Any additonal props to add to the element (e.g. data attributes). */
+    /** Any additonal props to add to the element (e.g. data attributes) */
     elementAttributes: PropTypes.object,
   }
 
@@ -283,7 +283,7 @@ class TextField extends React.Component {
             onKeyDown={this.handleKeyDown}
             autoComplete={autoComplete}
             placeholder=""
-            { ...elementAttributes }
+            {...elementAttributes}
           />
         </div>
 

--- a/src/components/Forms/__tests__/TextField.spec.js
+++ b/src/components/Forms/__tests__/TextField.spec.js
@@ -5,22 +5,36 @@ import { mount } from 'enzyme'
 import { spy } from 'sinon'
 import TextField from '../TextField'
 
-const defaultTextField = (
+const defaultProps = {
+  id: 'test_id',
+  name: 'test',
+  type: 'email',
+  floatingLabelText: 'Email',
+  hintText: 'Enter your email address',
+}
+
+const defaultTextField = props => (
   <StyleRoot>
     <div>
-      <TextField
-        id="test_id"
-        name="test"
-        type="email"
-        floatingLabelText="Email"
-        hintText="Enter your email address"
-      />
+      <TextField {...props} />
     </div>
   </StyleRoot>
 )
 
 it('renders TextField correctly', () => {
-  const tree = renderer.create(defaultTextField).toJSON()
+  const tree = renderer.create(defaultTextField(defaultProps)).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders TextField without label correctly', () => {
+  const props = {
+    ...defaultProps,
+    floatingLabelText: null,
+    elementAttributes: {
+      'aria-label': 'enter email',
+    },
+  }
+  const tree = renderer.create(defaultTextField(props)).toJSON()
   expect(tree).toMatchSnapshot()
 })
 
@@ -47,7 +61,7 @@ it('fires the onFocus prop', () => {
 })
 
 it('fires the triggerFocus method', () => {
-  const wrapper = mount(defaultTextField)
+  const wrapper = mount(defaultTextField(defaultProps))
 
   wrapper
     .find('TextField')

--- a/src/components/Forms/__tests__/__snapshots__/TextField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/TextField.spec.js.snap
@@ -143,6 +143,126 @@ exports[`renders TextField correctly 1`] = `
 </div>
 `;
 
+exports[`renders TextField without label correctly 1`] = `
+<div
+  data-radium={true}
+>
+  <div>
+    <div
+      data-radium={true}
+      style={
+        Object {
+          "cursor": "auto",
+          "display": "inline-block",
+          "position": "relative",
+          "width": "343px",
+        }
+      }
+    >
+      <div
+        data-radium={true}
+        style={
+          Object {
+            "borderRadius": "4px",
+            "position": "relative",
+          }
+        }
+      >
+        <div
+          data-radium={true}
+          id="hint_test_id"
+          style={
+            Object {
+              "color": "#BDBDBD",
+              "cursor": "inherit",
+              "fontSize": "16px",
+              "opacity": 0,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "transform": "scale(1) translate(9px, 26px)",
+              "transformOrigin": "left top",
+              "transition": "visibility 0ms linear 250ms, opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "visibility": "hidden",
+              "zIndex": 1,
+            }
+          }
+        >
+          Enter your email address
+        </div>
+        <input
+          aria-describedby="hint_test_id"
+          aria-invalid={false}
+          aria-label="enter email"
+          aria-required={undefined}
+          autoComplete="on"
+          data-radium={true}
+          defaultValue={null}
+          disabled={false}
+          id="test_id"
+          name="test"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          placeholder=""
+          style={
+            Object {
+              "WebkitOpacity": 1,
+              "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+              "backgroundColor": "#FFF",
+              "border": "solid 1px #BDBDBD",
+              "borderRadius": "4px",
+              "boxSizing": "border-box",
+              "color": "#424242",
+              "fontSize": "16px",
+              "height": "56px",
+              "marginBottom": 0,
+              "marginLeft": 0,
+              "marginRight": 0,
+              "marginTop": 0,
+              "paddingBottom": 8,
+              "paddingLeft": 8,
+              "paddingRight": 8,
+              "paddingTop": "25px",
+              "position": "relative",
+              "width": "100%",
+            }
+          }
+          type="email"
+          value={undefined}
+        />
+      </div>
+      <div
+        aria-atomic={true}
+        aria-live="assertive"
+        data-radium={true}
+        id="error_test_id"
+        style={
+          Object {
+            "color": "#B30029",
+            "display": "none",
+            "fontSize": "12px",
+            "marginLeft": "1px",
+            "marginTop": "2px",
+            "opacity": "0",
+            "pointerEvents": "none",
+            "textAlign": "left",
+            "transition": "opacity 250ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+          }
+        }
+      />
+    </div>
+  </div>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
 exports[`uses a custom theme for all child components if one is provided 1`] = `
 <div
   data-radium={true}


### PR DESCRIPTION
Allow for passing element attributes as props for overriding aria elements for accessibility purposes. Also, do not add `FloatingLabel` if no `floatingLabelText` is present.