### PR TITLE
Removing aria-haspopup from Dropdownmenu.js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,12 @@ jobs:
       - run:
           name: Run tests
           command: yarn test
-      
-      - run: 
+
+      - run:
           name: Upload code coverage report
           command: ./node_modules/.bin/codecov
-      
-      - run: 
+
+      - run:
           name: Upload code coverage report - CoverAlls
           command: ./node_modules/.bin/coveralls < ./coverage/lcov.info
+test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
 
       - run: yarn install
 
@@ -35,4 +35,3 @@ jobs:
       - run:
           name: Upload code coverage report - CoverAlls
           command: ./node_modules/.bin/coveralls < ./coverage/lcov.info
-test

--- a/src/components/Forms/__tests__/__snapshots__/Select.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/Select.spec.js.snap
@@ -35,12 +35,10 @@ exports[`renders Select correctly 1`] = `
           >
             <div
               aria-expanded={false}
-              aria-haspopup={true}
               data-radium={true}
               elementAttributes={
                 Object {
                   "aria-expanded": false,
-                  "aria-haspopup": true,
                 }
               }
               onBlur={[Function]}
@@ -414,12 +412,10 @@ exports[`renders Select w/ server error correctly 1`] = `
           >
             <div
               aria-expanded={false}
-              aria-haspopup={true}
               data-radium={true}
               elementAttributes={
                 Object {
                   "aria-expanded": false,
-                  "aria-haspopup": true,
                 }
               }
               onBlur={[Function]}
@@ -795,12 +791,10 @@ exports[`renders disabled Select correctly 1`] = `
           >
             <div
               aria-expanded={false}
-              aria-haspopup={true}
               data-radium={true}
               elementAttributes={
                 Object {
                   "aria-expanded": false,
-                  "aria-haspopup": true,
                 }
               }
               onBlur={[Function]}
@@ -1174,12 +1168,10 @@ exports[`renders invalid Select correctly 1`] = `
           >
             <div
               aria-expanded={false}
-              aria-haspopup={true}
               data-radium={true}
               elementAttributes={
                 Object {
                   "aria-expanded": false,
-                  "aria-haspopup": true,
                 }
               }
               onBlur={[Function]}
@@ -1552,12 +1544,10 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
         >
           <div
             aria-expanded={false}
-            aria-haspopup={true}
             data-radium={true}
             elementAttributes={
               Object {
                 "aria-expanded": false,
-                "aria-haspopup": true,
               }
             }
             onBlur={[Function]}

--- a/src/components/Menus/DropdownMenu.js
+++ b/src/components/Menus/DropdownMenu.js
@@ -180,10 +180,8 @@ class DropdownMenu extends React.Component {
         },
         onMouseDown: this.handleClick,
         elementAttributes: {
-          'aria-haspopup': true,
           'aria-expanded': open,
         },
-        'aria-haspopup': true,
         'aria-expanded': open,
       })
     }

--- a/src/components/Menus/__tests__/__snapshots__/DropdownMenu.spec.js.snap
+++ b/src/components/Menus/__tests__/__snapshots__/DropdownMenu.spec.js.snap
@@ -20,7 +20,6 @@ exports[`renders DropdownMenu with icons and trigger correctly 1`] = `
       >
         <button
           aria-expanded={false}
-          aria-haspopup={true}
           data-radium={true}
           disabled={false}
           onBlur={[Function]}


### PR DESCRIPTION
Received a report from accessibility auditors that aria-haspopup is not well supported and is really meant for menu and submenus. Support for aria-haspopup is coming slowly, but in its current state adding an aria-haspopup to custom select drop downs doesn't do much. When the attribute becomes more fleshed out, it may be that having it on this element may cause unforeseen future issues. For now, it was recommend we remove this attribute.

See: https://hub.accessible360.com/kb/articles/151