### PR TITLE
[ISSUE-333] Fixes <Tooltip /> whitespace for <Tooltip size="small" />

### DIFF
--- a/src/components/Tooltip/InnerToolTip.js
+++ b/src/components/Tooltip/InnerToolTip.js
@@ -50,9 +50,9 @@ const RESOLVED_COLOR = {
 const RESOLVED_SIZE = {
   small: {
     fontSize: '14px',
-    ...spacing.PADDDING_X_XS,
     paddingTop: '9px',
     paddingBottom: '9px',
+    ...spacing.PADDING_X_XS,
   },
   medium: {
     fontSize: '16px',

--- a/src/components/Tooltip/InnerToolTip.js
+++ b/src/components/Tooltip/InnerToolTip.js
@@ -23,6 +23,12 @@ const styles = {
   },
 }
 
+const spanStyles = {
+  root: {
+    position: 'relative',
+  },
+}
+
 const RESOLVED_COLOR = {
   primary: {
     background: colors.GREEN_500,
@@ -107,8 +113,10 @@ class InnerToolTip extends PureComponent {
   render() {
     return (
       <Fade>
-        {this.renderArrow()}
-        <div style={this.contentStyles}>{this.props.children}</div>
+        <div style={this.contentStyles}>
+          {this.renderArrow()}
+          <span style={spanStyles.root}>{this.props.children}</span>
+        </div>
       </Fade>
     )
   }

--- a/src/components/Tooltip/InnerToolTip.js
+++ b/src/components/Tooltip/InnerToolTip.js
@@ -23,12 +23,6 @@ const styles = {
   },
 }
 
-const spanStyles = {
-  root: {
-    position: 'relative',
-  },
-}
-
 const RESOLVED_COLOR = {
   primary: {
     background: colors.GREEN_500,
@@ -113,10 +107,8 @@ class InnerToolTip extends PureComponent {
   render() {
     return (
       <Fade>
-        <div style={this.contentStyles}>
-          {this.renderArrow()}
-          <span style={spanStyles.root}>{this.props.children}</span>
-        </div>
+        {this.renderArrow()}
+        <div style={this.contentStyles}>{this.props.children}</div>
       </Fade>
     )
   }


### PR DESCRIPTION
## Context
https://github.com/instacart/Snacks/issues/333

## Problem
The left- and right-padding of small Tooltips was set to 0. This was a bit awkward when the tooltip was positioned `top` and `bottom` of target, but was particularly a problem for when the tooltip was positioned `right` or `left`, as the Tooltip Arrow would cover the inner content.

## Solution
Two small tweaks were made:
1. ~Wrapped inner content of tooltip to be `position: relative`, so that we can always ensure a higher z-index than non-crucial content.~
2. Turns out that the rouge issue here was of a silently failing import `...spacing.PADDDING_X_XS,` vs. `...spacing.PADDING_X_XS`.

## Screenshots

| `<Tooltip size="small" placement="left" />` | `<Tooltip size="small" placement="right" />`|
|--|--|
| <img width="271" alt="Screen Shot 2019-06-12 at 3 07 37 PM" src="https://user-images.githubusercontent.com/10468542/59379554-eb728200-8d24-11e9-8ee0-c622a01a2a33.png"> | <img width="287" alt="Screen Shot 2019-06-12 at 3 16 36 PM" src="https://user-images.githubusercontent.com/10468542/59379651-2c6a9680-8d25-11e9-9f78-a7e34446a15f.png"> |
| <img width="292" alt="Screen Shot 2019-06-17 at 1 40 53 PM" src="https://user-images.githubusercontent.com/10468542/59625124-7fb65d80-9106-11e9-9403-d514b3141015.png"> | <img width="306" alt="Screen Shot 2019-06-17 at 1 40 59 PM" src="https://user-images.githubusercontent.com/10468542/59625123-7fb65d80-9106-11e9-906b-33642e696f92.png"> |

