### PR TITLE
Fix release scripts

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,13 +1,20 @@
+function isBabelNode(caller) {
+  return !!(caller && caller.name === '@babel/node')
+}
+
 module.exports = api => {
   const env = api.env()
+  const isNode = api.caller(isBabelNode)
   const isTest = env === 'test'
+
+  const useESModules = !isTest && !isNode
 
   return {
     presets: [
       [
         '@babel/preset-env',
         {
-          modules: isTest ? 'commonjs' : false,
+          modules: useESModules ? false : 'commonjs',
           loose: true,
         },
       ],
@@ -22,7 +29,7 @@ module.exports = api => {
       ],
       ['@babel/plugin-proposal-class-properties', { loose: true }],
       ['@babel/plugin-proposal-object-rest-spread', { loose: true }],
-      ['@babel/transform-runtime', { useESModules: isTest ? false : true }],
+      ['@babel/transform-runtime', { useESModules }],
       '@babel/plugin-transform-react-constant-elements',
     ],
   }

--- a/scripts/release/build_esm.js
+++ b/scripts/release/build_esm.js
@@ -1,6 +1,6 @@
-const path = require('path')
-const fs = require('fs')
-const { execSync } = require('child_process')
+import path from 'path'
+import fs from 'fs'
+import { execSync } from 'child_process'
 
 const exec = command => execSync(command, { stdio: 'inherit' })
 

--- a/scripts/release/copy-types.js
+++ b/scripts/release/copy-types.js
@@ -1,6 +1,6 @@
-const path = require('path')
-const fse = require('fs-extra')
-const glob = require('glob')
+import path from 'path'
+import fse from 'fs-extra'
+import glob from 'glob'
 
 function copyTypes() {
   const from = path.resolve(__dirname, '../../src')


### PR DESCRIPTION
Broke the release scripts because I disabled module transpilation except for tests.

This was so webpack could handle the modules which allowed us take advantage of webpack's scope hoisting for the UMD build (which, for example, fixed the issue with duplicated babel helpers), and it's also the default for the ESM build.

Fixed this by transpiling modules when running babel-node.

Also changed the other scripts to use `import` that I had used `require` for.

Now they work:

```
yarn babel-node scripts/release/verify_build.js
$ /xxxxxxxxxxxxxxxxx/Snacks/node_modules/.bin/babel-node scripts/release/verify_build.js
✨  Done in 3.31s.
```