### PR TITLE
Use process.env.NODE_ENV for dev warning

### DIFF
--- a/src/styles/themer/withTheme.js
+++ b/src/styles/themer/withTheme.js
@@ -37,7 +37,7 @@ function withTheme(InnerComponent) {
     }
 
     validateSnacksTheme() {
-      if (__DEV__) {
+      if (process.env.NODE_ENV !== 'production') {
         // eslint-disable-line no-undef
         const { snacksTheme } = this.props
         const themeIsBad = snacksTheme && !Object.keys(cleanConfig(snacksTheme)).length

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = {
   },
   plugins: [
     new webpack.DefinePlugin({
-      __DEV__: JSON.stringify(true),
+      'process.env.NODE_ENV': JSON.stringify('development'),
     }),
     anaylzerEnabled && new BundleAnalyzerPlugin(), // optionally anaylze if flag passed in
   ].filter(i => !!i), // filter out false items

--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -37,7 +37,7 @@ module.exports = {
   },
   plugins: [
     new webpack.DefinePlugin({
-      __DEV__: JSON.stringify(false),
+      'process.env.NODE_ENV': JSON.stringify('production'),
     }),
   ],
   output: {


### PR DESCRIPTION
This caused problems for the ESM build unless the `___DEV___` global is defined.... as you can imagine