### PR TITLE
Add SVG component type declaration generation and verification

### DIFF
--- a/scripts/release/build_esm.js
+++ b/scripts/release/build_esm.js
@@ -1,22 +1,6 @@
-import path from 'path'
-import fs from 'fs'
 import { execSync } from 'child_process'
 
 const exec = command => execSync(command, { stdio: 'inherit' })
-
-const svgrTempDir = path.resolve(process.cwd(), 'tmp/svgr')
-const svgrAssetsDir = path.resolve(svgrTempDir, 'assets')
-const svgrComponentsDir = path.resolve(svgrTempDir, 'components')
-
-function ensureDir(dir) {
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir)
-  }
-}
-
-// svg will complain if the --out-dir does not exist
-ensureDir(svgrAssetsDir)
-ensureDir(svgrComponentsDir)
 
 console.log('Building ESM build...')
 
@@ -24,9 +8,16 @@ exec('yarn babel --out-dir dist/esm --ignore=**/__tests__/**,**/docs/** src')
 
 console.log('Building icon components with svgr')
 
-// do these separately so we don't catch the svg font, it has no ignore option
-exec('yarn svgr --filename-case=camel --ext="svg.js" -d tmp/svgr/assets src/assets')
-exec('yarn svgr --filename-case=camel --ext="svg.js" -d tmp/svgr/components src/components')
+function buildIconComponents(args = []) {
+  const finalArgs = [...args, '--filename-case=camel', '--no-prettier']
+  exec(`yarn svgr ${finalArgs.join(' ')} -d tmp/svgr/assets src/assets`)
+  exec(`yarn svgr ${finalArgs.join(' ')} -d tmp/svgr/components src/components`)
+}
+
+// build the JS files
+buildIconComponents(['--ext="svg.js"'])
+// build the d.ts files
+buildIconComponents(['--ext="svg.d.ts"', '--template scripts/svgDtsTemplate.js'])
 
 console.log('Babelifying icon components')
 

--- a/scripts/release/copy-types.js
+++ b/scripts/release/copy-types.js
@@ -2,8 +2,7 @@ import path from 'path'
 import fse from 'fs-extra'
 import glob from 'glob'
 
-function copyTypes() {
-  const from = path.resolve(__dirname, '../../src')
+function copyTypes(from) {
   const to = path.resolve(__dirname, '../../dist/esm')
   const files = glob.sync('**/*.d.ts', { cwd: from })
   const cmds = files.map(file => fse.copy(path.resolve(from, file), path.resolve(to, file)))
@@ -11,4 +10,9 @@ function copyTypes() {
   return Promise.all(cmds)
 }
 
-copyTypes()
+async function run() {
+  await copyTypes(path.resolve(__dirname, '../../src'))
+  await copyTypes(path.resolve(__dirname, '../../tmp/svgr'))
+}
+
+run()

--- a/scripts/release/verify_build.js
+++ b/scripts/release/verify_build.js
@@ -4,23 +4,52 @@
 // This also ensures that Snacks can be imported into a node environment
 
 // basic importing works (most issues will appear here)
-import * as Snacks from '../../dist/snacks'
+import { execSync } from 'child_process'
+import * as SnacksUMD from '../../dist/snacks'
 import colors from '../../src/styles/colors'
 import zIndex from '../../src/styles/zIndex'
 
-// verify colors from dist equal src
-Object.keys(Snacks.colors).forEach((color) => {
-  if (colors[color] !== Snacks.colors[color]) {
-    throw new Error(`Snacks dist file colors do not match - expect ${colors[color]}, but saw ${Snacks.colors[color]}`)
-  }
-})
+const exec = command => execSync(command, { stdio: 'inherit' })
 
-// verify zIndex from dist equal src
-Object.keys(Snacks.zIndex).forEach((zValue) => {
-  const sourceObj = zIndex[zValue]
-  const builtObj = Snacks.zIndex[zValue]
+function verifyBuild(SnacksBuild) {
+  // verify colors from dist equal src
+  Object.keys(SnacksBuild.colors).forEach(color => {
+    if (colors[color] !== SnacksBuild.colors[color]) {
+      throw new Error(
+        `Snacks dist file colors do not match - expect ${colors[color]}, but saw ${
+          SnacksBuild.colors[color]
+        }`
+      )
+    }
+  })
 
-  if (sourceObj.zIndex !== builtObj.zIndex) {
-    throw new Error(`Snacks dist file zIndex do not match - expect ${sourceObj.zIndex}, but saw ${builtObj.zIndex}`)
-  }
-})
+  // verify zIndex from dist equal src
+  Object.keys(SnacksBuild.zIndex).forEach(zValue => {
+    const sourceObj = zIndex[zValue]
+    const builtObj = SnacksBuild.zIndex[zValue]
+
+    if (sourceObj.zIndex !== builtObj.zIndex) {
+      throw new Error(
+        `Snacks dist file zIndex do not match - expect ${sourceObj.zIndex}, but saw ${
+          builtObj.zIndex
+        }`
+      )
+    }
+  })
+}
+
+console.log('Verifying UMD build')
+
+verifyBuild(SnacksUMD)
+
+console.log('Verifying ESM build (bundling and importing)')
+
+exec('yarn webpack --config=webpack.verify-esm.config.js')
+
+const SnacksESMBundle = require('../../tmp/esm-bundle')
+
+verifyBuild(SnacksESMBundle)
+
+console.log('Verifying typings')
+
+exec('yarn tsc -p tsconfig.verify-build.json')

--- a/scripts/svgDtsTemplate.js
+++ b/scripts/svgDtsTemplate.js
@@ -1,0 +1,16 @@
+function svgDtsTemplate({ types: t, template }, _, { componentName }) {
+  const typeScriptTpl = template.smart({ plugins: ['typescript'] })
+  const {
+    typeAnnotation,
+  } = typeScriptTpl.ast`type Foo = React.FunctionComponent<React.SVGProps<SVGSVGElement>>`
+  const componentNameWithAnnotation = {
+    ...componentName,
+    typeAnnotation: t.tsTypeAnnotation(typeAnnotation),
+  }
+  return typeScriptTpl.ast`
+    import * as React from 'react';
+    declare const ${componentNameWithAnnotation}
+    export default ${componentName};
+  `
+}
+module.exports = svgDtsTemplate

--- a/src/components/SVGIcon/svg.d.ts
+++ b/src/components/SVGIcon/svg.d.ts
@@ -1,4 +1,0 @@
-declare module '*.svg' {
-  const content: string
-  export default content
-}

--- a/tsconfig.verify-build.json
+++ b/tsconfig.verify-build.json
@@ -2,10 +2,12 @@
   "extends": "@instacart/tsconfig/babel",
   "compilerOptions": {
     "noEmit": true,
-    "allowSyntheticDefaultImports": false,
+    "allowSyntheticDefaultImports": false
   },
+  "include": [
+    "./dist/esm/**/*"
+  ],
   "exclude": [
-    "dist",
     "node_modules"
   ]
 }

--- a/webpack.verify-esm.config.js
+++ b/webpack.verify-esm.config.js
@@ -1,0 +1,29 @@
+const path = require('path')
+const webpack = require('webpack')
+
+module.exports = {
+  mode: 'production',
+  module: {
+    rules: [{ test: /\.js$/, loaders: ['babel-loader'], exclude: /node_modules/ }],
+  },
+  entry: './dist/esm/index.js',
+  output: {
+    library: 'Snacks',
+    filename: 'esm-bundle.js',
+    libraryTarget: 'umd',
+    path: path.resolve(__dirname, 'tmp'),
+    globalObject: "typeof self !== 'undefined' ? self : this",
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    }),
+  ],
+  externals: {
+    react: 'react',
+    'react-dom': 'react-dom',
+    radium: 'radium',
+    'prop-types': 'prop-types',
+  },
+  stats: 'errors-only',
+}


### PR DESCRIPTION
The generated SVG components weren't getting declarations generated. Didn't see this in a consuming project initially as the TS compiler allowed the global declaration for `.svg` modules in said project to apply to the imports ending in `.svg`.

This now generates declarations for those files.

I've also added two additional steps to the build verification process:

- Will verify that the TS compiler is satisfied with the declarations output into the `dist` dir
- Ensures that the ESM build bundles without error and performs the same checks against the resulting bundle as we perform against the UMD build.