### PR TITLE
Adds props.customElement to <Button />

### DIFF
--- a/src/components/Buttons/Button.d.ts
+++ b/src/components/Buttons/Button.d.ts
@@ -40,11 +40,7 @@ export interface ButtonProps
    */
   href?: string
 
-  /**
-    * If passed, users will have the ability to render a custom element
-    * or React Component in the DOM while leveraging the styling of a
-    * Snacks Button (e.g., using react-router's Link)
-    */
+  /** A custom element to render instead of a button. */
   elementType?: React.ElementType
 }
 

--- a/src/components/Buttons/Button.d.ts
+++ b/src/components/Buttons/Button.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { RadiumStyles, ElementAttributes } from '../..'
 import { WithThemeInjectedProps, ApplyWithTheme } from '../../styles/themer/withTheme'
 
+
 export interface ButtonProps
   extends WithThemeInjectedProps,
     Pick<
@@ -39,6 +40,13 @@ export interface ButtonProps
    * tag with the supplied href value.
    */
   href?: string
+
+  /**
+    * If passed, users will have the ability to render a custom element
+    * or React Component in the DOM while leveraging the styling of a
+    * Snacks Button (e.g., using react-router's Link)
+    */
+  elementType?: keyof JSX.IntrinsicElements | Function
 }
 
 declare const Button: ApplyWithTheme<React.ComponentClass<ButtonProps>>

--- a/src/components/Buttons/Button.d.ts
+++ b/src/components/Buttons/Button.d.ts
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { RadiumStyles, ElementAttributes } from '../..'
 import { WithThemeInjectedProps, ApplyWithTheme } from '../../styles/themer/withTheme'
 
-
 export interface ButtonProps
   extends WithThemeInjectedProps,
     Pick<

--- a/src/components/Buttons/Button.d.ts
+++ b/src/components/Buttons/Button.d.ts
@@ -45,7 +45,7 @@ export interface ButtonProps
     * or React Component in the DOM while leveraging the styling of a
     * Snacks Button (e.g., using react-router's Link)
     */
-  elementType?: keyof JSX.IntrinsicElements | React.ElementType
+  elementType?: React.ElementType
 }
 
 declare const Button: ApplyWithTheme<React.ComponentClass<ButtonProps>>

--- a/src/components/Buttons/Button.d.ts
+++ b/src/components/Buttons/Button.d.ts
@@ -45,7 +45,7 @@ export interface ButtonProps
     * or React Component in the DOM while leveraging the styling of a
     * Snacks Button (e.g., using react-router's Link)
     */
-  elementType?: keyof JSX.IntrinsicElements | Function
+  elementType?: keyof JSX.IntrinsicElements | React.ElementType
 }
 
 declare const Button: ApplyWithTheme<React.ComponentClass<ButtonProps>>

--- a/src/components/Buttons/Button.js
+++ b/src/components/Buttons/Button.js
@@ -322,11 +322,7 @@ Button.propTypes = {
   /** Snacks theme attributes provided by `Themer` */
   snacksTheme: themePropTypes,
 
-  /**
-    If passed, users will have the ability to render a custom element
-    or React Component in the DOM while leveraging the styling of a
-    Snacks Button (e.g., using react-router's Link)
-  */
+  /** A custom element to render instead of a button. */
   elementType: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 }
 

--- a/src/components/Buttons/Button.js
+++ b/src/components/Buttons/Button.js
@@ -207,7 +207,7 @@ const getSnacksStyles = props => {
 const Button = props => {
   const snacksStyles = getSnacksStyles(props)
 
-  const ElementType = props.customElement ? props.customElement : props.href ? 'a' : 'button'
+  const ElementType = props.elementType ? props.elementType : props.href ? 'a' : 'button'
 
   const finalProps = {
     disabled: props.disabled,
@@ -238,13 +238,9 @@ const Button = props => {
       props.onMouseDown(e, props)
     },
     ...props.elementAttributes,
-    ...props.customElementProps,
   }
   if (props.href) {
     finalProps.href = props.href
-  }
-  if (props.customElement) {
-    finalProps.role = 'button'
   }
 
   const icon = typeof props.icon === 'string' ? <Icon name={props.icon} /> : props.icon
@@ -329,9 +325,7 @@ Button.propTypes = {
     or React Component in the DOM while leveraging the styling of a
     Snacks Button (e.g., using react-router's Link)
   */
-  customElement: PropTypes.node,
-
-  customElementProps: PropTypes.object,
+  elementType: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 }
 
 Button.defaultProps = {

--- a/src/components/Buttons/Button.js
+++ b/src/components/Buttons/Button.js
@@ -207,7 +207,7 @@ const getSnacksStyles = props => {
 const Button = props => {
   const snacksStyles = getSnacksStyles(props)
 
-  const ElementType = props.href ? 'a' : 'button'
+  const ElementType = props.customElement ? props.customElement : props.href ? 'a' : 'button'
 
   const finalProps = {
     disabled: props.disabled,
@@ -238,9 +238,13 @@ const Button = props => {
       props.onMouseDown(e, props)
     },
     ...props.elementAttributes,
+    ...props.customElementProps,
   }
   if (props.href) {
     finalProps.href = props.href
+  }
+  if (props.customElement) {
+    finalProps.role = 'button'
   }
 
   const icon = typeof props.icon === 'string' ? <Icon name={props.icon} /> : props.icon
@@ -319,6 +323,15 @@ Button.propTypes = {
 
   /** Snacks theme attributes provided by `Themer` */
   snacksTheme: themePropTypes,
+
+  /**
+    If passed, users will have the ability to render a custom element
+    or React Component in the DOM while leveraging the styling of a
+    Snacks Button (e.g., using react-router's Link)
+  */
+  customElement: PropTypes.node,
+
+  customElementProps: PropTypes.object,
 }
 
 Button.defaultProps = {

--- a/src/components/Buttons/Button.js
+++ b/src/components/Buttons/Button.js
@@ -210,9 +210,7 @@ const Button = props => {
   const ElementType = props.elementType ? props.elementType : props.href ? 'a' : 'button'
 
   const finalProps = {
-    disabled: props.disabled,
     tabIndex: props.tabIndex,
-    type: props.type,
     style: [
       baseStyles,
       sizeStyles[props.size],
@@ -238,6 +236,10 @@ const Button = props => {
       props.onMouseDown(e, props)
     },
     ...props.elementAttributes,
+  }
+  if (ElementType === 'button') {
+    finalProps.disabled = props.disabled
+    finalProps.type = props.type
   }
   if (props.href) {
     finalProps.href = props.href

--- a/src/components/Buttons/__tests__/Button.spec.js
+++ b/src/components/Buttons/__tests__/Button.spec.js
@@ -6,6 +6,8 @@ import { spy } from 'sinon'
 import Icon from '../../Icon/Icon'
 import Button from '../Button'
 
+const Foo = props => <div {...props} />
+
 describe('Button', () => {
   it('renders all sizes correctly', () => {
     const testCases = [
@@ -143,6 +145,28 @@ describe('Button', () => {
       <StyleRoot>
         <Button href="/carrot" snacksType="primary">
           Hi
+        </Button>
+      </StyleRoot>
+    )
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('can render a different parent element if HTML element is passed', () => {
+    const tree = renderer.create(
+      <StyleRoot>
+        <Button snacksType="primary" elementType="span">
+          Renders span as parent
+        </Button>
+      </StyleRoot>
+    )
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('can render a different parent element if React component is passed', () => {
+    const tree = renderer.create(
+      <StyleRoot>
+        <Button snacksType="primary" elementType={Foo}>
+          Renders Foo as parent
         </Button>
       </StyleRoot>
     )

--- a/src/components/Buttons/__tests__/__snapshots__/Button.spec.js.snap
+++ b/src/components/Buttons/__tests__/__snapshots__/Button.spec.js.snap
@@ -61,7 +61,6 @@ exports[`Button can render a different parent element if HTML element is passed 
 >
   <span
     data-radium={true}
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -95,7 +94,6 @@ exports[`Button can render a different parent element if HTML element is passed 
         "whiteSpace": "nowrap",
       }
     }
-    type="button"
   >
     Renders span as parent
   </span>
@@ -114,7 +112,6 @@ exports[`Button can render a different parent element if React component is pass
   data-radium={true}
 >
   <div
-    disabled={false}
     onClick={[Function]}
     onMouseDown={[Function]}
     style={
@@ -160,7 +157,6 @@ exports[`Button can render a different parent element if React component is pass
         undefined,
       ]
     }
-    type="button"
   >
     Renders Foo as parent
   </div>
@@ -180,7 +176,6 @@ exports[`Button can render as a link if an href is provided 1`] = `
 >
   <a
     data-radium={true}
-    disabled={false}
     href="/carrot"
     onBlur={[Function]}
     onClick={[Function]}
@@ -216,7 +211,6 @@ exports[`Button can render as a link if an href is provided 1`] = `
         "whiteSpace": "nowrap",
       }
     }
-    type="button"
   >
     Hi
   </a>

--- a/src/components/Buttons/__tests__/__snapshots__/Button.spec.js.snap
+++ b/src/components/Buttons/__tests__/__snapshots__/Button.spec.js.snap
@@ -55,6 +55,125 @@ exports[`Button applies the elementAttributes prop correctly 1`] = `
 </div>
 `;
 
+exports[`Button can render a different parent element if HTML element is passed 1`] = `
+<div
+  data-radium={true}
+>
+  <span
+    data-radium={true}
+    disabled={false}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "alignItems": "center",
+        "backgroundColor": "#43B02A",
+        "backgroundImage": "none",
+        "border": "1px solid transparent",
+        "borderBottomLeftRadius": 4,
+        "borderBottomRightRadius": 4,
+        "borderTopLeftRadius": 4,
+        "borderTopRightRadius": 4,
+        "color": "#FFFFFF",
+        "cursor": "pointer",
+        "display": "inline-flex",
+        "fontSize": "16px",
+        "fontWeight": 600,
+        "height": "40px",
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "touchAction": "manipulation",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
+      }
+    }
+    type="button"
+  >
+    Renders span as parent
+  </span>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`Button can render a different parent element if React component is passed 1`] = `
+<div
+  data-radium={true}
+>
+  <div
+    disabled={false}
+    onClick={[Function]}
+    onMouseDown={[Function]}
+    style={
+      Array [
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "alignItems": "center",
+          "backgroundImage": "none",
+          "border": "1px solid transparent",
+          "borderBottomLeftRadius": 4,
+          "borderBottomRightRadius": 4,
+          "borderTopLeftRadius": 4,
+          "borderTopRightRadius": 4,
+          "cursor": "pointer",
+          "display": "inline-flex",
+          "fontWeight": 600,
+          "touchAction": "manipulation",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
+        },
+        Object {
+          "fontSize": "16px",
+          "height": "40px",
+          "paddingLeft": 16,
+          "paddingRight": 16,
+        },
+        Object {
+          ":active": Object {
+            "backgroundColor": "#146e04",
+          },
+          ":focus": Object {
+            "backgroundColor": "#146e04",
+          },
+          ":hover": Object {
+            "backgroundColor": "#177D05",
+          },
+          "backgroundColor": "#43B02A",
+          "color": "#FFFFFF",
+        },
+        false,
+        false,
+        undefined,
+      ]
+    }
+    type="button"
+  >
+    Renders Foo as parent
+  </div>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+  />
+</div>
+`;
+
 exports[`Button can render as a link if an href is provided 1`] = `
 <div
   data-radium={true}

--- a/src/components/Buttons/docs/Button.md
+++ b/src/components/Buttons/docs/Button.md
@@ -233,23 +233,3 @@ import { Button, Icon } from 'ic-snacks'
     </span>
   </div>
 ```
-
-### Custom Element
-Buttons can render a custom base HTML Element or React Component, while leveraging the full styling of a Snacks Button.
-
-```jsx
-import { Button, Icon, Link } from 'ic-snacks';
-
-  <div style={{padding: '24px'}}>
-    <span style={{marginRight: '24px'}}>
-      <Button snacksStyle="primary" size="small" customElement='span'>
-        Using a Custom HTML Element
-      </Button>
-    </span>
-    <span style={{marginRight: '24px'}}>
-      <Button snacksStyle="primary" size="small" customElement={Link} customElementProps={{ href: '/foo' }}>
-        Using a Custom Component
-      </Button>
-    </span>
-  </div>
-```

--- a/src/components/Buttons/docs/Button.md
+++ b/src/components/Buttons/docs/Button.md
@@ -233,3 +233,23 @@ import { Button, Icon } from 'ic-snacks'
     </span>
   </div>
 ```
+
+### Custom Element
+Buttons can render a custom base HTML Element or React Component, while leveraging the full styling of a Snacks Button.
+
+```jsx
+import { Button, Icon, Link } from 'ic-snacks';
+
+  <div style={{padding: '24px'}}>
+    <span style={{marginRight: '24px'}}>
+      <Button snacksStyle="primary" size="small" customElement='span'>
+        Using a Custom HTML Element
+      </Button>
+    </span>
+    <span style={{marginRight: '24px'}}>
+      <Button snacksStyle="primary" size="small" customElement={Link} customElementProps={{ href: '/foo' }}>
+        Using a Custom Component
+      </Button>
+    </span>
+  </div>
+```


### PR DESCRIPTION
## Problem
Trying to figure out an elegant way to:
1. Allow Snacks users to pass a custom component to the `<Button />` component to leverage styling (perfect use case: `react-router`'s `<Link />`)
2. while maintaining the source / approach of `<Button />` mostly untouched

*The motivation for this is mainly to avoid improper HTML practices with nesting a `<Button />` inside a `<Link />`.*

## Solution
Current approach leverages existing dynamic element creation to add a 3rd option (`a`, `button`, `props.customElement`). ~Adds an additional `customElementProps` prop to allow users to specify props they may need (`to`, `q`, etc.).~ `customElementProps` removed in order to favour `elementAttributes`.