### PR TITLE
Change circle caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,19 +9,19 @@ jobs:
     steps:
       - checkout
 
-      # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - yarn-node-modules-v1-{{ checksum "yarn.lock" }}
 
-      - run: yarn install
+      - run:
+          name: Install npm packages
+          command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
 
       - save_cache:
+          name: Save Yarn Package Cache
+          key: yarn-node-modules-v1-{{ checksum "yarn.lock" }}
           paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+            - ~/.cache/yarn
 
       # run tests!
       - run:


### PR DESCRIPTION
This is the correct way to cache yarn npm deps on circle, hopefully should fix the issue we had after the eslint upgrade from occurring again.