### PR TITLE
allow auto width for gridTemplateColumns

### DIFF
--- a/src/components/Grid/Row.js
+++ b/src/components/Grid/Row.js
@@ -61,23 +61,28 @@ const styles = {
   },
 }
 
+const overrideColumnsStyles = (maxColumns, autoWidth) => {
+  const columnWidth = autoWidth ? 'auto' : `${responsive.columnWidth}px`
+  if (supportsCSSGrid()) {
+    return {
+      display: 'grid',
+      gridTemplateColumns: `repeat(${maxColumns}, ${columnWidth})`,
+      justifyContent: 'center',
+    }
+  }
+
+  return {
+    width: `${maxColumns * responsive.columnWidth}px`,
+    marginTop: 0,
+    marginRight: 'auto',
+    marginBottom: 0,
+    marginLeft: 'auto',
+  }
+}
+
 const getMaxColumnsStyles = props => {
   const { maxColumns, autoWidth } = props
-
-  const columnWidth = autoWidth ? 'auto' : `${responsive.columnWidth}px`
-  const override = supportsCSSGrid()
-    ? {
-        display: 'grid',
-        gridTemplateColumns: `repeat(${maxColumns}, ${columnWidth})`,
-        justifyContent: 'center',
-      }
-    : {
-        width: `${maxColumns * responsive.columnWidth}px`,
-        marginTop: 0,
-        marginRight: 'auto',
-        marginBottom: 0,
-        marginLeft: 'auto',
-      }
+  const override = overrideColumnsStyles(maxColumns, autoWidth)
 
   if (maxColumns <= 6) {
     return {

--- a/src/components/Grid/Row.js
+++ b/src/components/Grid/Row.js
@@ -62,12 +62,13 @@ const styles = {
 }
 
 const getMaxColumnsStyles = props => {
-  const { maxColumns } = props
+  const { maxColumns, autoWidth } = props
 
+  const columnWidth = autoWidth ? 'auto' : `${responsive.columnWidth}px`
   const override = supportsCSSGrid()
     ? {
         display: 'grid',
-        gridTemplateColumns: `repeat(${maxColumns}, ${responsive.columnWidth}px)`,
+        gridTemplateColumns: `repeat(${maxColumns}, ${columnWidth})`,
         justifyContent: 'center',
       }
     : {


### PR DESCRIPTION
In chrome, grid doesn't render correctly with pixel width.  auto width would fix this issue.
<img width="1270" alt="Screen Shot 2019-09-03 at 2 01 04 PM" src="https://user-images.githubusercontent.com/11140001/64379948-d1bf9e80-cfe4-11e9-9bb9-eb813f2b5771.png">

