### PR TITLE
Update RadiumStyles

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -53,9 +53,14 @@ interface RadiumCSSProperties extends React.CSSProperties {
   ':active'?: React.CSSProperties
 }
 
-type RadiumStylesBase = RadiumCSSProperties | RadiumCSSProperties[]
+// Radium ignores non-objects, so you can do `this.state.isCool && styles.cool`
+type RadiumStylesBase = RadiumCSSProperties | number | string | undefined | false | null
 
-export type RadiumStyles = RadiumStylesBase | RadiumStylesBase[]
+// Radium supports style arrays and merges multiple style objects
+interface RadiumStylesArray extends Array<RadiumStyles> {}
+
+// Radium recursively merges style arrays
+export type RadiumStyles = RadiumStylesBase | RadiumStylesArray
 
 export type ElementAttributes<T> = (T extends keyof JSX.IntrinsicElements
   ? React.ComponentPropsWithoutRef<T>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -47,20 +47,30 @@ import Portal from './components/Portal/Portal'
 import Text from './components/Typography/Text'
 import { themePropTypes } from './styles/themer/utils'
 
-interface RadiumCSSProperties extends React.CSSProperties {
-  ':hover'?: React.CSSProperties
-  ':focus'?: React.CSSProperties
-  ':active'?: React.CSSProperties
-}
+// Radium only supports these interaction styles
+type RadiumPseudos = ':hover' | ':focus' | ':active'
+type RadiumCSSPseudosObject = { [K in RadiumPseudos]?: RadiumCSSObject }
 
-// Radium ignores non-objects, so you can do `this.state.isCool && styles.cool`
-type RadiumStylesBase = RadiumCSSProperties | number | string | undefined | false | null
+// Allows for arbitrary properties as a last resort -- this enables support for "@media xxxxxxx" etc
+type RadiumCSSOthersObject = { [propertiesName: string]: RadiumStyles }
+
+interface RadiumCSSObject
+  extends React.CSSProperties,
+    RadiumCSSPseudosObject,
+    RadiumCSSOthersObject {}
 
 // Radium supports style arrays and merges multiple style objects
 interface RadiumStylesArray extends Array<RadiumStyles> {}
 
-// Radium recursively merges style arrays
-export type RadiumStyles = RadiumStylesBase | RadiumStylesArray
+// Radium ignores non-objects/arrays so you can do `this.state.isCool && styles.cool`
+export type RadiumStyles =
+  | null
+  | undefined
+  | boolean
+  | number
+  | string
+  | RadiumCSSObject
+  | RadiumStylesArray
 
 export type ElementAttributes<T> = (T extends keyof JSX.IntrinsicElements
   ? React.ComponentPropsWithoutRef<T>

--- a/test/typescript/foobar.tsx
+++ b/test/typescript/foobar.tsx
@@ -2,12 +2,30 @@ import * as React from 'react'
 import { Button, SVGIcon } from '../../src'
 
 export function Foo() {
-  return <Button onClick={(e: React.MouseEvent<HTMLButtonElement>) => e}>Foo</Button>
+  return (
+    <Button
+      style={[
+        { background: 'green', ':hover': { background: 'purple' } },
+        true && { color: 'red' },
+      ]}
+      onClick={(e: React.MouseEvent<HTMLButtonElement>) => e}
+    >
+      Foo
+    </Button>
+  )
 }
 
 export function Foo2() {
   return (
-    <Button href="foo.html" onClick={(e: React.MouseEvent<HTMLAnchorElement>) => e}>
+    <Button
+      style={{
+        '@media (max-width: 123px)': {
+          background: 'green',
+        },
+      }}
+      href="foo.html"
+      onClick={(e: React.MouseEvent<HTMLAnchorElement>) => e}
+    >
       Foo
     </Button>
   )


### PR DESCRIPTION
Update RadiumStyles to support the following scenarios:
- Radium supports recursively merging arrays of style objects.
- Radium ignores any non-objects, so you can have inline expressions to conditionally include style objects.