### PR TITLE
[TextField] aria-required --> required

### DIFF
--- a/src/components/Forms/TextField.js
+++ b/src/components/Forms/TextField.js
@@ -266,7 +266,7 @@ class TextField extends React.Component {
             disabled={disabled}
             name={name}
             type={type}
-            aria-required={required}
+            required={required}
             aria-invalid={hasError}
             aria-describedby={[
               hasError ? `error_${inputId}` : null,


### PR DESCRIPTION
I think `aria-required` does not dynamically update the field valid/invalid status when input is entered. `required` does that based on [MDN](https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/Form_validation#The_required_attribute) docs.