### PR TITLE
Make React.CSSProperties compatible with RadiumStyles

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -73,6 +73,7 @@ export type RadiumStyles =
   | string
   | RadiumCSSObject
   | RadiumStylesArray
+  | React.CSSProperties
 
 export type ElementAttributes<T> = (T extends keyof JSX.IntrinsicElements
   ? React.ComponentPropsWithoutRef<T>

--- a/test/typescript/foobar.tsx
+++ b/test/typescript/foobar.tsx
@@ -1,12 +1,19 @@
 import * as React from 'react'
 import { Button, SVGIcon } from '../../src'
 
+const cssProperties: React.CSSProperties = { display: 'block' }
+
 export function Foo() {
   return (
     <Button
       style={[
         { background: 'green', ':hover': { background: 'purple' } },
         true && { color: 'red' },
+        cssProperties,
+        {
+          display: 'block',
+          '@media (max-width: 123px)': { display: 'inline' },
+        },
       ]}
       onClick={(e: React.MouseEvent<HTMLButtonElement>) => e}
     >


### PR DESCRIPTION
Currently `React.CSSProperties` is not compatible with RadiumStyles because of the index type in `RadiumCSSObject`.  Adding `React.CSSProperties` to the `RadiumStyles` union type makes a single or array of `React.CSSProperties` compatible with RadiumStyles.