### PR TITLE
Add displayOnOffLabel type to Switch

### DIFF
--- a/src/components/Buttons/Switch.d.ts
+++ b/src/components/Buttons/Switch.d.ts
@@ -9,6 +9,7 @@ export interface SwitchProps
     keyof WithThemeInjectedProps | 'renderInputButton' | 'btnType'
   > {
   name?: string
+  displayOnOffLabel?: boolean
 }
 
 declare const Switch: React.FunctionComponent<SwitchProps>


### PR DESCRIPTION
`Switch` component is missing a type definition for `displayOnOffLabel`, which is throwing an error when being used in a typescript file.

See below:

<img width="803" alt="Screen Shot 2019-10-17 at 2 09 26 PM" src="https://user-images.githubusercontent.com/32278764/67047812-e7e27380-f0e7-11e9-8b8a-01c6e28bdb69.png">

