### PR TITLE
Fix select ref

### DIFF
--- a/src/components/Forms/Select.js
+++ b/src/components/Forms/Select.js
@@ -122,7 +122,7 @@ const getSnackStyles = snacksTheme => {
   }
 }
 
-@withTheme
+@withTheme({ forwardRef: true })
 @FormComponent
 @Radium
 class Select extends React.PureComponent {

--- a/src/components/Forms/__tests__/Select.spec.js
+++ b/src/components/Forms/__tests__/Select.spec.js
@@ -170,3 +170,26 @@ it('uses a custom theme for all child components if one is provided', () => {
 
   expect(tree).toMatchSnapshot()
 })
+
+it('should provide access to the trigger element via its ref', () => {
+  let selectRef
+
+  const wrapper = mount(
+    <StyleRoot>
+      <Select
+        id="test_id"
+        name="country"
+        floatingLabelText="Country"
+        hintText="Select a country"
+        onOpen={() => {}}
+        onClose={() => {}}
+        onSelect={() => {}}
+        ref={node => (selectRef = node)}
+      >
+        <MenuItem label="United States" value="US" />
+      </Select>
+    </StyleRoot>
+  )
+
+  expect(selectRef.FormComponent.trigger).toBe(wrapper.find('div[role="button"]').getDOMNode())
+})


### PR DESCRIPTION
In the last release, we updated how `withTheme` refs work. We missed adding the flag for ref forwarding to this component.

I have added it, and a test to verify the ref is passed as intended.