### PR TITLE
[A11y] Prevent tabbing to aria-hidden menu items

### DIFF
--- a/src/components/Forms/__tests__/__snapshots__/Select.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/Select.spec.js.snap
@@ -267,7 +267,7 @@ exports[`renders Select correctly 1`] = `
                           "paddingTop": 16,
                         }
                       }
-                      tabIndex={0}
+                      tabIndex={-1}
                     >
                       <div
                         data-radium={true}
@@ -311,7 +311,7 @@ exports[`renders Select correctly 1`] = `
                           "paddingTop": 16,
                         }
                       }
-                      tabIndex={0}
+                      tabIndex={-1}
                     >
                       <div
                         data-radium={true}
@@ -642,7 +642,7 @@ exports[`renders Select w/ server error correctly 1`] = `
                           "paddingTop": 16,
                         }
                       }
-                      tabIndex={0}
+                      tabIndex={-1}
                     >
                       <div
                         data-radium={true}
@@ -686,7 +686,7 @@ exports[`renders Select w/ server error correctly 1`] = `
                           "paddingTop": 16,
                         }
                       }
-                      tabIndex={0}
+                      tabIndex={-1}
                     >
                       <div
                         data-radium={true}
@@ -1019,7 +1019,7 @@ exports[`renders disabled Select correctly 1`] = `
                           "paddingTop": 16,
                         }
                       }
-                      tabIndex={0}
+                      tabIndex={-1}
                     >
                       <div
                         data-radium={true}
@@ -1063,7 +1063,7 @@ exports[`renders disabled Select correctly 1`] = `
                           "paddingTop": 16,
                         }
                       }
-                      tabIndex={0}
+                      tabIndex={-1}
                     >
                       <div
                         data-radium={true}
@@ -1394,7 +1394,7 @@ exports[`renders invalid Select correctly 1`] = `
                           "paddingTop": 16,
                         }
                       }
-                      tabIndex={0}
+                      tabIndex={-1}
                     >
                       <div
                         data-radium={true}
@@ -1438,7 +1438,7 @@ exports[`renders invalid Select correctly 1`] = `
                           "paddingTop": 16,
                         }
                       }
-                      tabIndex={0}
+                      tabIndex={-1}
                     >
                       <div
                         data-radium={true}
@@ -1768,7 +1768,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                         "paddingTop": 16,
                       }
                     }
-                    tabIndex={0}
+                    tabIndex={-1}
                   >
                     <div
                       data-radium={true}

--- a/src/components/Menus/Menu.js
+++ b/src/components/Menus/Menu.js
@@ -147,7 +147,7 @@ class Menu extends React.Component {
   }
 
   renderChildren() {
-    const { children, onSelect } = this.props
+    const { children, onSelect, ariaHidden } = this.props
     const { currentTabIndex } = this.state
     let index = 0
 
@@ -160,6 +160,7 @@ class Menu extends React.Component {
           focus: currentTabIndex === index,
           _onClick: onSelect,
           onMenuItemFocus: this.handleMenuItemFocus,
+          ...(ariaHidden && { tabIndex: -1 }),
         })
         index += 1
         return component

--- a/src/components/Menus/__tests__/Menu.spec.js
+++ b/src/components/Menus/__tests__/Menu.spec.js
@@ -58,3 +58,22 @@ it('should fire onSelect when a MenuItem is selected', () => {
     .simulate('click')
   expect(onSelect.calledOnce).toBe(true)
 })
+
+it('should set tabIndex to -1 for children when aria-hidden is true', () => {
+  const wrapper = mount(
+    <StyleRoot>
+      <div>
+        <Menu ariaHidden>
+          <MenuItem label="First" value="First" />
+        </Menu>
+      </div>
+    </StyleRoot>
+  )
+
+  expect(
+    wrapper
+      .find(MenuItem)
+      .first()
+      .prop('tabIndex')
+  ).toBe(-1)
+})

--- a/src/components/Menus/__tests__/__snapshots__/DropdownMenu.spec.js.snap
+++ b/src/components/Menus/__tests__/__snapshots__/DropdownMenu.spec.js.snap
@@ -793,7 +793,7 @@ exports[`renders DropdownMenu with icons and trigger correctly 1`] = `
                       "paddingTop": 16,
                     }
                   }
-                  tabIndex={0}
+                  tabIndex={-1}
                 >
                   <div
                     data-radium={true}
@@ -878,7 +878,7 @@ exports[`renders DropdownMenu with icons and trigger correctly 1`] = `
                       "paddingTop": 16,
                     }
                   }
-                  tabIndex={0}
+                  tabIndex={-1}
                 >
                   <div
                     data-radium={true}
@@ -964,7 +964,7 @@ exports[`renders DropdownMenu with icons and trigger correctly 1`] = `
                       "paddingTop": 16,
                     }
                   }
-                  tabIndex={0}
+                  tabIndex={-1}
                 >
                   <div
                     data-radium={true}


### PR DESCRIPTION
Currently if a Menu is aria-hidden, you can still tab to its child menu items.
`aria-hidden="true"` does not hide focusable elements from screen reader or keyboard users as TAB key navigation ignores this attribute.

This PR sets a `tab-index` of `-1` to all child menu items of an aria-hidden menu.