### PR TITLE
ScrollTrack - Add missing type import

### DIFF
--- a/src/components/ScrollTrack/ScrollTrack.d.ts
+++ b/src/components/ScrollTrack/ScrollTrack.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { RadiumStyles } from '../..'
+import { Omit } from '../../utils'
 
 interface CallbackProps {
   atStart: boolean


### PR DESCRIPTION
The `Omit` type was not imported.