### PR TITLE
Expose some 'react-text-mask' props on the MaskedTextField component

### DIFF
--- a/src/components/Forms/MaskedTextField.js
+++ b/src/components/Forms/MaskedTextField.js
@@ -120,6 +120,11 @@ export const maskedTextFieldPropTypes = {
   floatingLabelText: PropTypes.string,
   /** Sets width to 100% */
   fullWidth: PropTypes.bool,
+  /**
+   * Tells the input whether to be in guide mode or not.
+   * https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#guide
+   */
+  guide: PropTypes.bool,
   /** Sets width to 162px */
   halfWidth: PropTypes.bool,
   /** FormComponent error for validation */
@@ -132,6 +137,13 @@ export const maskedTextFieldPropTypes = {
   inputStyle: PropTypes.object,
   /** Set by FormComponent by default.   */
   isValid: PropTypes.bool,
+  /**
+   * Changes the behavour of the input mask.
+   * When `true`, adding or deleting characters will not affect the positions of existing characters.
+   * When `false`, adding characters causes existing characters to advance.
+   * https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#keepcharpositions
+   */
+  keepCharPositions: PropTypes.bool,
   /** onFocus callback */
   onFocus: PropTypes.func,
   /** onChange callback
@@ -170,6 +182,8 @@ class MaskedTextField extends React.Component {
     autoComplete: 'on',
     disabled: false,
     defaultValue: null,
+    guide: false,
+    keepCharPositions: true,
     onChange: NoOp,
     onKeyDown: NoOp,
     onFocus: NoOp,
@@ -237,10 +251,12 @@ class MaskedTextField extends React.Component {
       defaultValue,
       disabled,
       fullWidth,
+      guide,
       halfWidth,
       hasError,
       id: inputId,
       isValid,
+      keepCharPositions,
       name,
       required,
       serverError,
@@ -288,7 +304,7 @@ class MaskedTextField extends React.Component {
             mask={mask}
             pipe={pipe}
             id={inputId}
-            guide={false}
+            guide={guide}
             name={name}
             aria-required={required}
             aria-invalid={hasError}
@@ -301,7 +317,7 @@ class MaskedTextField extends React.Component {
             placeholder=""
             defaultValue={value !== undefined ? undefined : defaultValue}
             disabled={disabled}
-            keepCharPositions
+            keepCharPositions={keepCharPositions}
             type={this.props.type}
             render={(ref, props) => (
               <input

--- a/src/components/Forms/__tests__/__snapshots__/DateField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/DateField.spec.js.snap
@@ -106,10 +106,12 @@ exports[`renders correctly 1`] = `
                 disabled={false}
                 floatingLabelText="Date of Birth"
                 getValue={[Function]}
+                guide={false}
                 hasError={false}
                 hintText="MM/DD/YYYY"
                 id="test_id"
                 isValid={true}
+                keepCharPositions={true}
                 mask={
                   Array [
                     /\\\\d/,
@@ -504,10 +506,12 @@ exports[`renders correctly with focus state 1`] = `
                 disabled={false}
                 floatingLabelText="Date of Birth"
                 getValue={[Function]}
+                guide={false}
                 hasError={false}
                 hintText="MM/DD/YYYY"
                 id="test_id"
                 isValid={true}
+                keepCharPositions={true}
                 mask={
                   Array [
                     /\\\\d/,
@@ -948,10 +952,12 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                 disabled={false}
                 floatingLabelText="Date of Birth"
                 getValue={[Function]}
+                guide={false}
                 hasError={false}
                 hintText="MM/DD/YYYY"
                 id="test_id"
                 isValid={true}
+                keepCharPositions={true}
                 mask={
                   Array [
                     /\\\\d/,

--- a/src/components/Forms/__tests__/__snapshots__/MaskedTextField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/MaskedTextField.spec.js.snap
@@ -94,9 +94,11 @@ exports[`renders correctly 1`] = `
               disabled={false}
               floatingLabelText="SSN"
               getValue={[Function]}
+              guide={false}
               hasError={false}
               id="test_id"
               isValid={true}
+              keepCharPositions={true}
               mask={
                 Array [
                   /\\\\d/,
@@ -475,9 +477,11 @@ exports[`renders correctly with focus state 1`] = `
               disabled={false}
               floatingLabelText="SSN"
               getValue={[Function]}
+              guide={false}
               hasError={false}
               id="test_id"
               isValid={true}
+              keepCharPositions={true}
               mask={
                 Array [
                   /\\\\d/,
@@ -888,9 +892,11 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
               disabled={false}
               floatingLabelText="SSN"
               getValue={[Function]}
+              guide={false}
               hasError={false}
               id="test_id"
               isValid={true}
+              keepCharPositions={true}
               mask={
                 Array [
                   /\\\\d/,

--- a/src/components/Forms/__tests__/__snapshots__/PhoneNumberField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/PhoneNumberField.spec.js.snap
@@ -115,10 +115,12 @@ exports[`renders correctly 1`] = `
                 disabled={false}
                 floatingLabelText="Phone Number"
                 getValue={[Function]}
+                guide={false}
                 hasError={false}
                 hintText="(555) 555-555"
                 id="test_id"
                 isValid={true}
+                keepCharPositions={true}
                 mask={
                   Array [
                     "(",
@@ -528,10 +530,12 @@ exports[`renders correctly with focus state 1`] = `
                 disabled={false}
                 floatingLabelText="Phone Number"
                 getValue={[Function]}
+                guide={false}
                 hasError={false}
                 hintText="(555) 555-555"
                 id="test_id"
                 isValid={true}
+                keepCharPositions={true}
                 mask={
                   Array [
                     "(",
@@ -987,10 +991,12 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                 disabled={false}
                 floatingLabelText="Phone Number"
                 getValue={[Function]}
+                guide={false}
                 hasError={false}
                 hintText="(555) 555-555"
                 id="test_id"
                 isValid={true}
+                keepCharPositions={true}
                 mask={
                   Array [
                     "(",


### PR DESCRIPTION
Expose some props on react-text-mask so consuming applications can tweak the mask behaviour.

The exposed props are optional, and default to the existing hardcoded props.

Needed to fork the repo as I don't have write permissions to instacart/snacks