### PR TITLE
tooltip: extend props to support backgroundColor

### DIFF
--- a/src/components/Tooltip/InnerToolTip.js
+++ b/src/components/Tooltip/InnerToolTip.js
@@ -67,7 +67,7 @@ class InnerToolTip extends PureComponent {
     children: PropTypes.node,
     snacksStyle: PropTypes.oneOf(['primary', 'secondary', 'dark']),
     size: PropTypes.oneOf(['small', 'medium', 'large']),
-    style: PropTypes.shape({
+    customStyle: PropTypes.shape({
       border: PropTypes.string,
       padding: PropTypes.string,
       boxShadow: PropTypes.string,
@@ -89,12 +89,12 @@ class InnerToolTip extends PureComponent {
   }
 
   get contentStyles() {
-    const { size, style, snacksStyle } = this.props
+    const { size, customStyle, snacksStyle } = this.props
     return {
       ...styles.innerContent,
       ...RESOLVED_SIZE[size],
       ...RESOLVED_COLOR[snacksStyle],
-      ...style,
+      ...customStyle,
     }
   }
 

--- a/src/components/Tooltip/InnerToolTip.js
+++ b/src/components/Tooltip/InnerToolTip.js
@@ -71,6 +71,7 @@ class InnerToolTip extends PureComponent {
       border: PropTypes.string,
       padding: PropTypes.string,
       boxShadow: PropTypes.string,
+      backgroundColor: PropTypes.string,
     }),
     arrowStyle: PropTypes.shape({
       border: PropTypes.string,

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -101,12 +101,6 @@ class Tooltip extends PureComponent {
       overlayStyle,
     } = this.props
 
-    if (style) {
-      console.warn(
-        'You have passed a `style` prop which will be deprecated in a future version of this component. Use `customStyle` instead.'
-      )
-    }
-
     return (
       <div>
         {this.renderTriggerElement()}
@@ -119,6 +113,7 @@ class Tooltip extends PureComponent {
         >
           <InnerToolTip
             size={size}
+            // @todo(JP): kill references to style
             customStyle={customStyle || style}
             arrowStyle={arrowStyle}
             snacksStyle={snacksStyle}

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -14,6 +14,7 @@ class Tooltip extends PureComponent {
       border: PropTypes.string,
       padding: PropTypes.string,
       boxShadow: PropTypes.string,
+      backgroundColor: PropTypes.string,
     }),
     overlayStyle: PropTypes.shape({}),
     arrowStyle: PropTypes.shape({

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -14,6 +14,12 @@ class Tooltip extends PureComponent {
       border: PropTypes.string,
       padding: PropTypes.string,
       boxShadow: PropTypes.string,
+    }),
+    // phasing in a new style override prop to avoid using native react prop
+    customStyle: PropTypes.shape({
+      border: PropTypes.string,
+      padding: PropTypes.string,
+      boxShadow: PropTypes.string,
       backgroundColor: PropTypes.string,
     }),
     overlayStyle: PropTypes.shape({}),
@@ -88,11 +94,18 @@ class Tooltip extends PureComponent {
       placement,
       size,
       style,
+      customStyle,
       arrowStyle,
       snacksStyle,
       isVisible,
       overlayStyle,
     } = this.props
+
+    if (style) {
+      console.warn(
+        'You have passed a `style` prop which will be deprecated in a future version of this component. Use `customStyle` instead.'
+      )
+    }
 
     return (
       <div>
@@ -104,7 +117,12 @@ class Tooltip extends PureComponent {
           onRootClose={this.handleHideToolTip}
           style={overlayStyle}
         >
-          <InnerToolTip size={size} style={style} arrowStyle={arrowStyle} snacksStyle={snacksStyle}>
+          <InnerToolTip
+            size={size}
+            customStyle={customStyle || style}
+            arrowStyle={arrowStyle}
+            snacksStyle={snacksStyle}
+          >
             {children}
           </InnerToolTip>
         </TooltipOverlay>


### PR DESCRIPTION
This PR extends Tooltip to accept `backgroundColor` style.

Use case:

https://instacart.quip.com/n7AzALPs30F7/PRD-Tooltips-1st-Journey-Education

The rest of the functionality described in the PRD can be accomplished with child components of the Tooltip.

An alternative approach would be to create a new `snacksStyle` preset to match whichever direction the onboarding tooltip design goes in the future. This seems like overkill for now, but is worth considering.