### PR TITLE
v0.0.150: update tooltip type interface to include new style prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ic-snacks",
-  "version": "0.0.149",
+  "version": "0.0.150",
   "description": "The Instacart Component Library for Web",
   "main": "dist/snacks.js",
   "module": "dist/esm/index.js",

--- a/src/components/Tooltip/Tooltip.d.ts
+++ b/src/components/Tooltip/Tooltip.d.ts
@@ -13,6 +13,14 @@ export interface TooltipProps {
     boxShadow?: string
   }
 
+  // phasing in a new style override prop to avoid using native react prop
+  customStyle?: {
+    border?: string
+    padding?: string
+    boxShadow?: string
+    backgroundColor?: string
+  }
+
   overlayStyle?: React.CSSProperties
 
   arrowStyle?: {


### PR DESCRIPTION
Previous PR (https://github.com/instacart/Snacks/pull/420) neglected to update TS type interface, causing type issues when trying to use it in application code.