### PR TITLE
h* tags have default styles which don't make sense for this inline element. Reset these styles since consumers can't control the internal styling of the label

### DIFF
--- a/src/components/NavigationPills/NavigationPills.js
+++ b/src/components/NavigationPills/NavigationPills.js
@@ -10,7 +10,7 @@ const styles = {
   labelStyles: {
     margin: '0 10px 0 0',
     display: 'inline',
-    fontSize: 'inherot',
+    fontSize: 'inherit',
   },
   wrapperStyles: {
     display: 'inline-block',

--- a/src/components/NavigationPills/NavigationPills.js
+++ b/src/components/NavigationPills/NavigationPills.js
@@ -8,7 +8,9 @@ import spacing from '../../styles/spacing'
 
 const styles = {
   labelStyles: {
-    marginRight: '10px',
+    margin: '0 10px 0 0',
+    display: 'inline',
+    fontSize: 'inherot',
   },
   wrapperStyles: {
     display: 'inline-block',

--- a/src/components/NavigationPills/__tests__/__snapshots__/NavigationPills.spec.js.snap
+++ b/src/components/NavigationPills/__tests__/__snapshots__/NavigationPills.spec.js.snap
@@ -105,7 +105,9 @@ exports[`renders NavigationPills correctly 1`] = `
               data-radium={true}
               style={
                 Object {
-                  "marginRight": "10px",
+                  "display": "inline",
+                  "fontSize": "inherit",
+                  "margin": "0 10px 0 0",
                 }
               }
             >
@@ -891,7 +893,9 @@ exports[`renders NavigationPills with each pill's elementAttributes correctly 1`
               data-radium={true}
               style={
                 Object {
-                  "marginRight": "10px",
+                  "display": "inline",
+                  "fontSize": "inherit",
+                  "margin": "0 10px 0 0",
                 }
               }
             >
@@ -1300,7 +1304,9 @@ exports[`renders NavigationPills with elementAttributes correctly 1`] = `
               data-radium={true}
               style={
                 Object {
-                  "marginRight": "10px",
+                  "display": "inline",
+                  "fontSize": "inherit",
+                  "margin": "0 10px 0 0",
                 }
               }
             >
@@ -1698,7 +1704,9 @@ exports[`renders NavigationPills with inner elementAttributes correctly 1`] = `
               data-radium={true}
               style={
                 Object {
-                  "marginRight": "10px",
+                  "display": "inline",
+                  "fontSize": "inherit",
+                  "margin": "0 10px 0 0",
                 }
               }
             >


### PR DESCRIPTION
https://instacart.atlassian.net/browse/CS-22918

Unfortunately I didn't visually test my previous change and hadn't considered that `h2`s are `display: block` and have a large font size.

Before:
![image](https://user-images.githubusercontent.com/351106/92184482-2e2ae900-ee06-11ea-8d5e-ab95d0727c1f.png)


After

![image](https://user-images.githubusercontent.com/351106/92183981-b8724d80-ee04-11ea-8446-a873032c4ff9.png)
