### PR TITLE
feat: add props id, aria-selected, aria-disabled, and aria-label to button component

### DIFF
--- a/src/components/Buttons/Button.d.ts
+++ b/src/components/Buttons/Button.d.ts
@@ -3,6 +3,12 @@ import { RadiumStyles, ElementAttributes } from '../..'
 import { WithThemeInjectedProps, ApplyWithTheme } from '../../styles/themer/withTheme'
 
 export interface ButtonProps extends WithThemeInjectedProps {
+  'aria-selected'?: boolean
+
+  'aria-disabled'?: boolean
+
+  'aria-label'?: string
+
   children?: React.ReactNode
 
   /** Whether or not the button is disabled. */

--- a/src/components/Buttons/Button.d.ts
+++ b/src/components/Buttons/Button.d.ts
@@ -23,6 +23,9 @@ export interface ButtonProps extends WithThemeInjectedProps {
   /** Where the icon is positioned relative to primary text content. */
   iconPosition?: 'left' | 'right'
 
+  /** An optional id for the button element */
+  id?: string
+
   /** Reverses colors. Use for rendering buttons on dark backgrounds. */
   inverted?: boolean
 

--- a/src/components/Buttons/Button.js
+++ b/src/components/Buttons/Button.js
@@ -273,8 +273,8 @@ const Button = props => {
 }
 
 Button.propTypes = {
-  'aria-selected': PropTypes.boolean,
-  'aria-disabled': PropTypes.boolean,
+  'aria-selected': PropTypes.bool,
+  'aria-disabled': PropTypes.bool,
   'aria-label': PropTypes.string,
 
   /** Size of the button. */

--- a/src/components/Buttons/Button.js
+++ b/src/components/Buttons/Button.js
@@ -211,6 +211,7 @@ const Button = props => {
 
   const finalProps = {
     disabled: props.disabled,
+    id: props.id,
     tabIndex: props.tabIndex,
     type: props.type,
     style: [
@@ -283,6 +284,9 @@ Button.propTypes = {
 
   /** Sets the HTML type attribute on the element. */
   type: PropTypes.oneOf(['button', 'reset', 'submit']),
+
+  /** An optional id for the button element */
+  id: PropTypes.string,
 
   /**
     An optional icon. Can be a an icon name

--- a/src/components/Buttons/Button.js
+++ b/src/components/Buttons/Button.js
@@ -211,6 +211,9 @@ const Button = props => {
 
   const finalProps = {
     disabled: props.disabled,
+    'aria-selected': props['aria-selected'],
+    'aria-disabled': props['aria-disabled'],
+    'aria-label': props['aria-label'],
     id: props.id,
     tabIndex: props.tabIndex,
     type: props.type,
@@ -270,6 +273,10 @@ const Button = props => {
 }
 
 Button.propTypes = {
+  'aria-selected': PropTypes.boolean,
+  'aria-disabled': PropTypes.boolean,
+  'aria-label': PropTypes.string,
+
   /** Size of the button. */
   size: PropTypes.oneOf(['tiny', 'small', 'standard', 'large']),
 

--- a/src/components/Buttons/__tests__/Button.spec.js
+++ b/src/components/Buttons/__tests__/Button.spec.js
@@ -7,7 +7,25 @@ import Icon from '../../Icon/Icon'
 import Button from '../Button'
 
 describe('Button', () => {
-  it('should support button prop', () => {
+  it('should support aria-selected prop', () => {
+    const wrapper = mount(<Button aria-selected />)
+
+    expect(wrapper.find('button[aria-selected]')).toHaveLength(1)
+  })
+
+  it('should support aria-disabled prop', () => {
+    const wrapper = mount(<Button aria-disabled />)
+
+    expect(wrapper.find('button[aria-disabled]')).toHaveLength(1)
+  })
+
+  it('should support aria-label prop', () => {
+    const wrapper = mount(<Button aria-label="foo-bar" />)
+
+    expect(wrapper.find('button[aria-label="foo-bar"]')).toHaveLength(1)
+  })
+
+  it('should support id prop', () => {
     const wrapper = mount(<Button id="foo" />)
 
     expect(wrapper.find('button#foo')).toHaveLength(1)

--- a/src/components/Buttons/__tests__/Button.spec.js
+++ b/src/components/Buttons/__tests__/Button.spec.js
@@ -7,6 +7,12 @@ import Icon from '../../Icon/Icon'
 import Button from '../Button'
 
 describe('Button', () => {
+  it('should support button prop', () => {
+    const wrapper = mount(<Button id="foo" />)
+
+    expect(wrapper.find('button#foo')).toHaveLength(1)
+  })
+
   it('renders all sizes correctly', () => {
     const testCases = [
       { snacksStyle: 'primary', size: 'tiny' },

--- a/src/components/Menus/__tests__/__snapshots__/DropdownMenu.spec.js.snap
+++ b/src/components/Menus/__tests__/__snapshots__/DropdownMenu.spec.js.snap
@@ -109,6 +109,7 @@ exports[`renders DropdownMenu in open state correctly 1`] = `
                       aria-haspopup={true}
                       data-radium={true}
                       disabled={false}
+                      id="trigger"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onFocus={[Function]}


### PR DESCRIPTION
I'm working on https://instacart.atlassian.net/browse/CS-26787 which will require me to add an id and a number of aria props to the button in https://github.com/instacart/carrot/blob/master/customers/instacart/app/assets/javascripts/store_app/components/shared/ServiceTypeControl/index.jsx#L26