### PR TITLE
a11y: removing conditional from aria-describedBy in MaskedTextField

### DIFF
--- a/src/components/Forms/MaskedTextField.js
+++ b/src/components/Forms/MaskedTextField.js
@@ -292,7 +292,7 @@ class MaskedTextField extends React.Component {
             name={name}
             aria-required={required}
             aria-invalid={hasError}
-            aria-describedby={hasError ? `hint_${inputId} error_${inputId}` : `hint_${inputId}`}
+            aria-describedby={`hint_${inputId} error_${inputId}`}
             onBlur={this.handleInputBlur}
             onChange={this.handleInputChange}
             onFocus={this.handleInputFocus}

--- a/src/components/Forms/__tests__/__snapshots__/DateField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/DateField.spec.js.snap
@@ -374,7 +374,7 @@ exports[`renders correctly 1`] = `
                           </TextFieldHint>
                         </withRadiumContexts(TextFieldHint)>
                         <t
-                          aria-describedby="hint_test_id"
+                          aria-describedby="hint_test_id error_test_id"
                           aria-invalid={false}
                           autoComplete="on"
                           defaultValue={null}
@@ -408,7 +408,7 @@ exports[`renders correctly 1`] = `
                           type="tel"
                         >
                           <input
-                            aria-describedby="hint_test_id"
+                            aria-describedby="hint_test_id error_test_id"
                             aria-invalid={false}
                             autoComplete="on"
                             defaultValue={null}
@@ -905,7 +905,7 @@ exports[`renders correctly with focus state 1`] = `
                           </TextFieldHint>
                         </withRadiumContexts(TextFieldHint)>
                         <t
-                          aria-describedby="hint_test_id"
+                          aria-describedby="hint_test_id error_test_id"
                           aria-invalid={false}
                           autoComplete="on"
                           defaultValue={null}
@@ -939,7 +939,7 @@ exports[`renders correctly with focus state 1`] = `
                           type="tel"
                         >
                           <input
-                            aria-describedby="hint_test_id"
+                            aria-describedby="hint_test_id error_test_id"
                             aria-invalid={false}
                             autoComplete="on"
                             defaultValue={null}
@@ -1475,7 +1475,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                           </TextFieldHint>
                         </withRadiumContexts(TextFieldHint)>
                         <t
-                          aria-describedby="hint_test_id"
+                          aria-describedby="hint_test_id error_test_id"
                           aria-invalid={false}
                           autoComplete="on"
                           defaultValue={null}
@@ -1509,7 +1509,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                           type="tel"
                         >
                           <input
-                            aria-describedby="hint_test_id"
+                            aria-describedby="hint_test_id error_test_id"
                             aria-invalid={false}
                             autoComplete="on"
                             defaultValue={null}

--- a/src/components/Forms/__tests__/__snapshots__/MaskedTextField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/MaskedTextField.spec.js.snap
@@ -358,7 +358,7 @@ exports[`renders correctly 1`] = `
                         </TextFieldHint>
                       </withRadiumContexts(TextFieldHint)>
                       <t
-                        aria-describedby="hint_test_id"
+                        aria-describedby="hint_test_id error_test_id"
                         aria-invalid={false}
                         autoComplete="on"
                         defaultValue={null}
@@ -391,7 +391,7 @@ exports[`renders correctly 1`] = `
                         render={[Function]}
                       >
                         <input
-                          aria-describedby="hint_test_id"
+                          aria-describedby="hint_test_id error_test_id"
                           aria-invalid={false}
                           autoComplete="on"
                           defaultValue={null}
@@ -870,7 +870,7 @@ exports[`renders correctly with focus state 1`] = `
                         </TextFieldHint>
                       </withRadiumContexts(TextFieldHint)>
                       <t
-                        aria-describedby="hint_test_id"
+                        aria-describedby="hint_test_id error_test_id"
                         aria-invalid={false}
                         autoComplete="on"
                         defaultValue={null}
@@ -903,7 +903,7 @@ exports[`renders correctly with focus state 1`] = `
                         render={[Function]}
                       >
                         <input
-                          aria-describedby="hint_test_id"
+                          aria-describedby="hint_test_id error_test_id"
                           aria-invalid={false}
                           autoComplete="on"
                           defaultValue={null}
@@ -1407,7 +1407,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                         </TextFieldHint>
                       </withRadiumContexts(TextFieldHint)>
                       <t
-                        aria-describedby="hint_test_id"
+                        aria-describedby="hint_test_id error_test_id"
                         aria-invalid={false}
                         autoComplete="on"
                         defaultValue={null}
@@ -1440,7 +1440,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                         render={[Function]}
                       >
                         <input
-                          aria-describedby="hint_test_id"
+                          aria-describedby="hint_test_id error_test_id"
                           aria-invalid={false}
                           autoComplete="on"
                           defaultValue={null}

--- a/src/components/Forms/__tests__/__snapshots__/PhoneNumberField.spec.js.snap
+++ b/src/components/Forms/__tests__/__snapshots__/PhoneNumberField.spec.js.snap
@@ -389,7 +389,7 @@ exports[`renders correctly 1`] = `
                           </TextFieldHint>
                         </withRadiumContexts(TextFieldHint)>
                         <t
-                          aria-describedby="hint_test_id"
+                          aria-describedby="hint_test_id error_test_id"
                           aria-invalid={false}
                           autoComplete="on"
                           defaultValue={null}
@@ -426,7 +426,7 @@ exports[`renders correctly 1`] = `
                           type="tel"
                         >
                           <input
-                            aria-describedby="hint_test_id"
+                            aria-describedby="hint_test_id error_test_id"
                             aria-invalid={false}
                             autoComplete="on"
                             defaultValue={null}
@@ -938,7 +938,7 @@ exports[`renders correctly with focus state 1`] = `
                           </TextFieldHint>
                         </withRadiumContexts(TextFieldHint)>
                         <t
-                          aria-describedby="hint_test_id"
+                          aria-describedby="hint_test_id error_test_id"
                           aria-invalid={false}
                           autoComplete="on"
                           defaultValue={null}
@@ -975,7 +975,7 @@ exports[`renders correctly with focus state 1`] = `
                           type="tel"
                         >
                           <input
-                            aria-describedby="hint_test_id"
+                            aria-describedby="hint_test_id error_test_id"
                             aria-invalid={false}
                             autoComplete="on"
                             defaultValue={null}
@@ -1526,7 +1526,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                           </TextFieldHint>
                         </withRadiumContexts(TextFieldHint)>
                         <t
-                          aria-describedby="hint_test_id"
+                          aria-describedby="hint_test_id error_test_id"
                           aria-invalid={false}
                           autoComplete="on"
                           defaultValue={null}
@@ -1563,7 +1563,7 @@ exports[`uses a custom theme for all child components if one is provided 1`] = `
                           type="tel"
                         >
                           <input
-                            aria-describedby="hint_test_id"
+                            aria-describedby="hint_test_id error_test_id"
                             aria-invalid={false}
                             autoComplete="on"
                             defaultValue={null}


### PR DESCRIPTION
This fixes a missing aria-describedBy attribute on MaskedTextField.

It is missing because of the unnecessary conditional.

See in the screenshot that the id of the error text `error_userphone-45994` is not in the aria-describedBy of the input

![missing_aria-describedBy_attribute](https://user-images.githubusercontent.com/9440683/162348567-77c033b7-6d4b-4b9e-a1f0-97ff59302024.png)

